### PR TITLE
Add e.g. with multiple variables to aggregate.Rd

### DIFF
--- a/man/aggregate.Rd
+++ b/man/aggregate.Rd
@@ -56,6 +56,9 @@ if (require(rgeos)) {
 	ab = gUnaryUnion(as(meuse.grid, "SpatialPolygons"), meuse.grid$part.a)
 	x = aggregate(meuse["zinc"], ab, mean)
 	spplot(x)
+	# aggregation of multiple variables
+	x = aggregate(meuse[c("zinc", "copper")], ab, mean)
+	spplot(x)
 	# aggregation by attribute, then dissolve to polygon:
 	x = aggregate(meuse.grid["dist"], list(i=i))
 	spplot(x["i"])


### PR DESCRIPTION
I tried various changes but this seems the simplest.

It's a pity `example("aggregate.Spatial")` doesn't plot all the output - tried fixing that with `par(mfrow = c(2, 3)` but that doesn't seem to work with spplot. Any ideas? 

Fantastic function in any case - hope this helps make people aware of all its capabilities.
