### PR TITLE
Update argument offset in spsample.Rd

### DIFF
--- a/man/spsample.Rd
+++ b/man/spsample.Rd
@@ -40,7 +40,7 @@ for sampling on a hexagonal lattice; \code{"clustered"} for clustered sampling;
 \item{bb}{ bounding box of the sampled domain; setting this to a smaller
 value leads to sub-region sampling }
 \item{offset}{ for square cell-based sampling types (regular, stratified, 
-nonaligned): the offset (position) of the regular
+nonaligned, hexagonal): the offset (position) of the regular
 grid; the default for \code{spsample} methods is a random location in
 the unit cell [0,1] x [0,1], leading to a different grid after
 each call; if this is set to \code{c(0.5,0.5)}, the returned grid is


### PR DESCRIPTION
AFAIK, a sample of `type = "hexagonal"` also uses the values passed to argument `offset`, where we must use `offset = c(0.5, 0.5)` if we want a centric systematic hexagonal grid.
BTW, I think that the hexagonal grid produced by `spsample` actually is a triangular grid -- following examples in Yfantis, Flatman and Behar (1987). Efficiency of kriging estimation for square, triangular, and hexagonal grids. Mathematical Geology. 19:183-205. http://dx.doi.org/10.1007/BF00897746
