### PR TITLE
renewed fix Polygons comments bug in disaggregate

### DIFF
--- a/R/disaggregate.R
+++ b/R/disaggregate.R
@@ -56,7 +56,11 @@ explodePolygons <- function(x, ignoreholes=FALSE, ...) {
     count <- count + np[i]
     p <- c(p, pp)
   }
-  p <- rgeos::createSPComment(SpatialPolygons(p))
+  p <- SpatialPolygons(p)
+  ps <- slot(p, "polygons")
+  for (i in seq(along=ps))
+    comment(ps[[i]]) <- rgeos::createPolygonsComment(ps[[i]])
+  slot(p, "polygons") <- ps
   proj4string(p) <- crs
   
   if (.hasSlot(x, 'data')) {


### PR DESCRIPTION
The original fix worked with the reprex, but not with the real case. This fix works with the original shapefile case (all MULTIPOLYGON/POLYGON objects valid). This also works out of the box:

```
library(sf)
sf <- st_read(dsn = "2011 Voting District Boundary Shapefiles", layer = "MCDS", stringsAsFactors = FALSE)
sfd <- st_cast(sf, "POLYGON")
```
