### PR TITLE
does not shrink bbox on conversion from SpatialGrid toSpatialPixels

### DIFF
--- a/R/SpatialGrid-methods.R
+++ b/R/SpatialGrid-methods.R
@@ -28,6 +28,8 @@ SpatialGrid = function(grid, proj4string = CRS(as.character(NA))) {
 setAs("SpatialGrid", "SpatialPixels", 
 	function(from) { 
 		pts = as(from, "SpatialPoints")
+		pts@bbox[,1] = pts@bbox[,1] - 0.5 * from@grid@cellsize
+		pts@bbox[,2] = pts@bbox[,2] + 0.5 * from@grid@cellsize
 		new("SpatialPixels", pts, grid = from@grid, grid.index = 1:length(pts))
 	}
 )


### PR DESCRIPTION
MWE:
```R
> library(sp)
> mweGrid <- SpatialGrid(GridTopology(c(0,0),c(1,1), c(2,2)))
> mweGrid@bbox # half a cellsize beyond
      min max
[1,] -0.5 1.5
[2,] -0.5 1.5
> 
> mwePixel <- as(mweGrid, "SpatialPixels")
> mwePixel@bbox # exact on cell centres - unexpected
    min max
s1   0   1
s2   0   1
> 
> mwePoints <- as(mweGrid, "SpatialPoints")
> mwePoints@bbox # exact on cell centres, as expected
   min max
s1   0   1
s2   0   1
> 
> SpatialPixels(mwePoints)@bbox # half a cellsize beyond
    min max
s1 -0.5 1.5
s2 -0.5 1.5
> SpatialGrid(points2grid(mwePoints))@bbox # half a cellsize beyond
    min max
s1 -0.5 1.5
s2 -0.5 1.5
```