### PR TITLE
Fix minor typos in documentation

### DIFF
--- a/man/00sp.Rd
+++ b/man/00sp.Rd
@@ -73,7 +73,7 @@ is stored or a partial grid (i.e., only the non-missing valued cells);
 calling \link{coordinates} on them will give the coordinates for the
 grid cells.
 
-SpatialPoints, SpatialPixels and SpatialGrid can be of arbitray
+SpatialPoints, SpatialPixels and SpatialGrid can be of arbitrary
 dimension, although most of the effort is in making them work for two
 dimensional data.
 

--- a/man/CRS-class.Rd
+++ b/man/CRS-class.Rd
@@ -28,7 +28,7 @@ identicalCRS(x,y)
 }
 \arguments{
 \item{projargs}{A character string of projection arguments; the arguments must be entered exactly as in the PROJ.4 documentation; if the projection is unknown, use \code{as.character(NA)}, it may be missing or an empty string of zero length and will then set to the missing value.}
-\item{doCheckCRSArgs}{default TRUE, must be set to FALSE by package developers including \code{CRS} in an S4 class definition to avoid uncontrolable loading of the \pkg{rgdal} namespace}
+\item{doCheckCRSArgs}{default TRUE, must be set to FALSE by package developers including \code{CRS} in an S4 class definition to avoid uncontrollable loading of the \pkg{rgdal} namespace}
 \item{x}{object having a \link{proj4string} method,
 or if \code{y} is missing, list with objects that have a \code{proj4string} method}
 \item{y}{object of class \link{Spatial}, or having a \link{proj4string} method}

--- a/man/SpatialGrid.Rd
+++ b/man/SpatialGrid.Rd
@@ -73,7 +73,7 @@ SpatialGrid stores grid topology and may or may not store the coordinates
 of the actual points, which may form a subset of the full grid. To find
 out or change this, see \link{fullgrid}.
 
-points2grid tries to figure out the grid topology from points. It succees
+points2grid tries to figure out the grid topology from points. It succeeds
 only if points on a grid line have constant y column, and points on a
 grid column have constant x coordinate, etc. In other cases, use signif
 on the raw coordinate matrices to make sure this is the case.

--- a/man/SpatialGridDataFrame-class.Rd
+++ b/man/SpatialGridDataFrame-class.Rd
@@ -63,14 +63,14 @@ objects take the following arguments:
 \item{attr}{ integer or character, indicating the attribute variable to be plotted; default 1}
 \item{col}{ color ramp to be used; default \code{bpy.colors(100)} for continuous, or
    \code{RColorBrewer::brewer.pal(nlevels(x[[1]]), "Set2")} for factor variables}
-\item{breaks}{ for continous attributes: values at which color breaks should take place }
+\item{breaks}{ for continuous attributes: values at which color breaks should take place }
 \item{zlim}{ for continuous attributes: 
   numeric of length 2, specifying the range of attribute values to be plotted; 
   default to data range \code{range(as.numeric(x[[attr]])[is.finite(x[[attr]])])}}
 \item{axes}{ logical: draw x and y axes? default \code{FALSE}}
 \item{xaxs}{character, default "i", see \link{par}}
 \item{yaxs}{character, default equal to \code{xaxs}, see \link{par}}
-\item{at}{numeric or NULL, values at which axis tics and labes should be drawn; default NULL (use \link{pretty})}
+\item{at}{numeric or NULL, values at which axis tics and labels should be drawn; default NULL (use \link{pretty})}
 \item{border}{color, to be used for drawing grid lines; default NA (don't draw grid lines)}
 \item{axis.pos}{integer, 1-4; default 4, see \link{axis}}
 \item{add.axis}{logical: draw axis along scale? default \code{TRUE}}

--- a/man/meuse.Rd
+++ b/man/meuse.Rd
@@ -3,7 +3,7 @@
 \docType{data}
 \title{Meuse river data set}
 \description{
-This data set gives locations and topsoil heavy metal concentrations, along with a number of soil and landscape variablesat the observation locations, collected in a flood plain of the river Meuse, near the village of Stein (NL). Heavy metal concentrations are from composite samples of an area of approximately 15 m x 15 m.
+This data set gives locations and topsoil heavy metal concentrations, along with a number of soil and landscape variables at the observation locations, collected in a flood plain of the river Meuse, near the village of Stein (NL). Heavy metal concentrations are from composite samples of an area of approximately 15 m x 15 m.
 }
 \format{
   This data frame contains the following columns:

--- a/man/over.Rd
+++ b/man/over.Rd
@@ -75,7 +75,7 @@ with the inner and boundary of each \code{y} geometry.  The order
 in which matched \code{y} geometries are returned is determined by
 the dimension of the overlap (2: area overlap, 1: line in common,
 0: point in common), and then by the position in the string (1,
-2, 4, 5, meaning points in polygons are prefered over points on
+2, 4, 5, meaning points in polygons are preferred over points on
 polygon boundaries). 
 }
 

--- a/man/spsample.Rd
+++ b/man/spsample.Rd
@@ -26,7 +26,7 @@ makegrid(x, n = 10000, nsig = 2, cellsize, offset = rep(0.5, nrow(bb)),
 }
 \arguments{
 \item{x}{Spatial object; \code{spsample(x,...)} is a generic method for the
-existing \code{sample.Xxx} fumctions}
+existing \code{sample.Xxx} functions}
 \item{...}{ optional arguments, passed to the appropriate \code{sample.Xxx}
 functions; see NOTES for \code{nclusters} and \code{iter}}
 \item{n}{ (approximate) sample size }

--- a/man/zerodist.Rd
+++ b/man/zerodist.Rd
@@ -16,7 +16,7 @@ remove.duplicates(obj, zero = 0.0, remove.second = TRUE, memcmp = TRUE)
 \item{zero}{ distance values less than or equal to this threshold value are
 considered to have zero distance (default 0.0);
 units are those of the coordinates for projected data or unknown projection,
-or km if coordinates are defined to be longitute/latitude }
+or km if coordinates are defined to be longitude/latitude }
 \item{unique.ID}{logical; if TRUE, return an ID (integer) for each point 
 that is different only when two points do not share the same location }
 \item{memcmp}{use \code{memcmp} to find exactly equal coordinates; see NOTE}


### PR DESCRIPTION
I have been using the `sp` package for a few months now and am really enjoying it! Today I decided to take a closer look through the documentation so I could get more familiar with the available functions.

I noticed a few minor typos in the documentation. Please consider this PR to correct them.