### PR TITLE
restore CRS()-based comparison of proj4string()s [fixes #46]

### DIFF
--- a/R/CRS-methods.R
+++ b/R/CRS-methods.R
@@ -65,19 +65,19 @@ setMethod("show", "CRS", function(object) print.CRS(object))
 
 identicalCRS = function(x, y) {
 	if (! missing(y))
-		identicalCRS1(proj4string(x), proj4string(y))
+		identicalCRS1(CRS(proj4string(x)), CRS(proj4string(y)))
 	else { # x has to be list:
 		stopifnot(is.list(x))
 		if (length(x) > 1) {
-			p1 = proj4string(x[[1]])
-			!any(!sapply(x[-1], function(p2) identicalCRS1(proj4string(p2), p1)))
+			p1 = CRS(proj4string(x[[1]]))
+			!any(!sapply(x[-1], function(p2) identicalCRS1(CRS(proj4string(p2)), p1)))
 		} else
 			TRUE
 	}
 }
 
 identicalCRS1 = function(x, y) {
-  args_x <- strsplit(x, " +")[[1]]
-  args_y <- strsplit(y, " +")[[1]]
+  args_x <- strsplit(x@projargs, " +")[[1]]
+  args_y <- strsplit(y@projargs, " +")[[1]]
   setequal(args_x, args_y)
 }


### PR DESCRIPTION
This restores pre-#31 behaviour of `identicalCRS()` in that the projection arguments are checked via `CRS()` prior to assessing their equivalence. The internal auxiliary function `identicalCRS1()` now takes two CRS objects instead of plain proj4strings().