### PR TITLE
rchk MAKE_CLASS vulnerability

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: sp
-Version: 1.2-8
+Version: 1.3-1
 Title: Classes and Methods for Spatial Data
 Authors@R: c(person("Edzer", "Pebesma", role = c("aut", "cre"),
 				email = "edzer.pebesma@uni-muenster.de"),

--- a/inst/include/sp_xports.c
+++ b/inst/include/sp_xports.c
@@ -14,7 +14,7 @@ SEXP SP_PREFIX(sp_linkingTo_version)(void) {
 
 SEXP SP_PREFIX(Polygon_c)(const SEXP coords, const SEXP n, const SEXP ihole) {
 
-    SEXP SPans, labpt, Area, ringDir, hole;
+    SEXP SPans, labpt, Area, ringDir, hole, cls;
     double area, xc, yc;
     double *x, *y;
     int pc=0, rev=FALSE;
@@ -74,8 +74,9 @@ SEXP SP_PREFIX(Polygon_c)(const SEXP coords, const SEXP n, const SEXP ihole) {
         }
     }
 
-    PROTECT(SPans = NEW_OBJECT(MAKE_CLASS("Polygon"))); pc++;
-
+// rchk MAKE_CLASS allocates RSB 180602
+    PROTECT(cls = MAKE_CLASS("Polygon")); pc++;
+    PROTECT(SPans = NEW_OBJECT(cls)); pc++; 
     PROTECT(ringDir = NEW_INTEGER(1)); pc++;
     INTEGER_POINTER(ringDir)[0] = (area > 0.0) ? -1 : 1;
 // -1 cw hole, 1 ccw not-hole
@@ -179,7 +180,7 @@ SEXP SP_PREFIX(Polygon_validate_c)(const SEXP obj) {
 
 SEXP SP_PREFIX(Polygons_c)(const SEXP pls, const SEXP ID) {
 
-    SEXP ans, labpt, Area, plotOrder, crds, pl, n, hole, pls1, ID1;
+    SEXP ans, labpt, Area, plotOrder, crds, pl, n, hole, pls1, ID1, cls;
     int nps, i, pc=0, sumholes;
     double *areas, *areaseps, fuzz;
     int *po, *holes;
@@ -234,7 +235,9 @@ SEXP SP_PREFIX(Polygons_c)(const SEXP pls, const SEXP ID) {
         SET_VECTOR_ELT(pls1, (po[0] - R_OFFSET), pl);
     }
 
-    PROTECT(ans = NEW_OBJECT(MAKE_CLASS("Polygons"))); pc++;
+// rchk MAKE_CLASS allocates RSB 180602
+    PROTECT(cls = MAKE_CLASS("Polygons")); pc++;
+    PROTECT(ans = NEW_OBJECT(cls)); pc++;
     SET_SLOT(ans, install("Polygons"), pls1);
     SET_SLOT(ans, install("ID"), ID1);
 
@@ -318,10 +321,12 @@ SEXP SP_PREFIX(Polygons_validate_c)(const SEXP obj) {
 SEXP SP_PREFIX(SpatialPolygons_c)(const SEXP pls, const SEXP pO, 
 		const SEXP p4s) {
 
-    SEXP ans, bbox, ppO;
+    SEXP ans, bbox, ppO, cls;
     int pc=0;
 
-    PROTECT(ans = NEW_OBJECT(MAKE_CLASS("SpatialPolygons"))); pc++;
+// rchk MAKE_CLASS allocates RSB 180602
+    PROTECT(cls = MAKE_CLASS("SpatialPolygons")); pc++;
+    PROTECT(ans = NEW_OBJECT(cls)); pc++;
     // SET_SLOT(ans, install("polygons"), MAYBE_REFERENCED(pls) ? duplicate(pls) : pls);
     SET_SLOT(ans, install("polygons"), pls);
     // SET_SLOT(ans, install("proj4string"), MAYBE_REFERENCED(p4s) ? duplicate(p4s) : p4s);

--- a/man/image.Rd
+++ b/man/image.Rd
@@ -16,8 +16,8 @@ objects. }
         axes = FALSE, xlim = NULL,
 	ylim = NULL, add = FALSE, ..., asp = NA, setParUsrBB=FALSE,
         interpolate = FALSE, angle = 0, 
-	useRasterImage = !(.Platform$GUI[1] == "Rgui" && getIdentification() == "R Console") &&
-	    missing(breaks), breaks,
+	useRasterImage = !(.Platform$GUI[1] == "Rgui" &&
+        getIdentification() == "R Console") && missing(breaks), breaks,
 	zlim = range(as.numeric(x[[attr]])[is.finite(x[[attr]])]))
 \method{image}{SpatialPixelsDataFrame}(x, ...) 
 \method{image}{SpatialPixels}(x, ...) 

--- a/src/sp_xports.c
+++ b/src/sp_xports.c
@@ -14,7 +14,7 @@ SEXP SP_PREFIX(sp_linkingTo_version)(void) {
 
 SEXP SP_PREFIX(Polygon_c)(const SEXP coords, const SEXP n, const SEXP ihole) {
 
-    SEXP SPans, labpt, Area, ringDir, hole;
+    SEXP SPans, labpt, Area, ringDir, hole, cls;
     double area, xc, yc;
     double *x, *y;
     int pc=0, rev=FALSE;
@@ -74,8 +74,9 @@ SEXP SP_PREFIX(Polygon_c)(const SEXP coords, const SEXP n, const SEXP ihole) {
         }
     }
 
-    PROTECT(SPans = NEW_OBJECT(MAKE_CLASS("Polygon"))); pc++;
-
+// rchk MAKE_CLASS allocates RSB 180602
+    PROTECT(cls = MAKE_CLASS("Polygon")); pc++;
+    PROTECT(SPans = NEW_OBJECT(cls)); pc++; 
     PROTECT(ringDir = NEW_INTEGER(1)); pc++;
     INTEGER_POINTER(ringDir)[0] = (area > 0.0) ? -1 : 1;
 // -1 cw hole, 1 ccw not-hole
@@ -179,7 +180,7 @@ SEXP SP_PREFIX(Polygon_validate_c)(const SEXP obj) {
 
 SEXP SP_PREFIX(Polygons_c)(const SEXP pls, const SEXP ID) {
 
-    SEXP ans, labpt, Area, plotOrder, crds, pl, n, hole, pls1, ID1;
+    SEXP ans, labpt, Area, plotOrder, crds, pl, n, hole, pls1, ID1, cls;
     int nps, i, pc=0, sumholes;
     double *areas, *areaseps, fuzz;
     int *po, *holes;
@@ -234,7 +235,9 @@ SEXP SP_PREFIX(Polygons_c)(const SEXP pls, const SEXP ID) {
         SET_VECTOR_ELT(pls1, (po[0] - R_OFFSET), pl);
     }
 
-    PROTECT(ans = NEW_OBJECT(MAKE_CLASS("Polygons"))); pc++;
+// rchk MAKE_CLASS allocates RSB 180602
+    PROTECT(cls = MAKE_CLASS("Polygons")); pc++;
+    PROTECT(ans = NEW_OBJECT(cls)); pc++;
     SET_SLOT(ans, install("Polygons"), pls1);
     SET_SLOT(ans, install("ID"), ID1);
 
@@ -318,10 +321,12 @@ SEXP SP_PREFIX(Polygons_validate_c)(const SEXP obj) {
 SEXP SP_PREFIX(SpatialPolygons_c)(const SEXP pls, const SEXP pO, 
 		const SEXP p4s) {
 
-    SEXP ans, bbox, ppO;
+    SEXP ans, bbox, ppO, cls;
     int pc=0;
 
-    PROTECT(ans = NEW_OBJECT(MAKE_CLASS("SpatialPolygons"))); pc++;
+// rchk MAKE_CLASS allocates RSB 180602
+    PROTECT(cls = MAKE_CLASS("SpatialPolygons")); pc++;
+    PROTECT(ans = NEW_OBJECT(cls)); pc++;
     // SET_SLOT(ans, install("polygons"), MAYBE_REFERENCED(pls) ? duplicate(pls) : pls);
     SET_SLOT(ans, install("polygons"), pls);
     // SET_SLOT(ans, install("proj4string"), MAYBE_REFERENCED(p4s) ? duplicate(p4s) : p4s);


### PR DESCRIPTION
NEW_OBJECT(MAKE_CLASS()) does not PROTECT() the output of MAKE_CLASS(). In Matrix, there is

```
/**
 * A safe  NEW_OBJECT_OF_CLASS(cls),  where the caller must protect the
 * return value of this function
 *
 * @param an R character string specifying the name of a known S4 class
 */
SEXP NEW_OBJECT_OF_CLASS(const char* cls)
{
    SEXP ans = NEW_OBJECT(PROTECT(MAKE_CLASS(cls)));
    UNPROTECT(1);
    return ans;
}
```
but I chose to do it in the functions, incrementing the `pc` counter.

I guess that you do not have time to make an rchk container, but we need one quite urgently, to be able to see that works. The recipe is for Debian and Debian-based containers, which I would need to learn from near-zero. Is there any chance of trying this on **sp**, then on **rgeos** and **rgdal** because the **sp** issues spill over through LinkingTo:?