### PR TITLE
fix error for old PROJ/GDAL

### DIFF
--- a/R/CRS-methods.R
+++ b/R/CRS-methods.R
@@ -58,7 +58,13 @@ if (!is.R()) {
                 if (!is.na(uprojargs) && !res[[1]]) stop(res[[2]])
                 uprojargs <- res[[2]]
                 comm <- res[[3]]
-            } else stop("rgdal version mismatch")
+            } else { #stop("rgdal version mismatch")
+                if (!is.na(uprojargs)) {
+                    res <- rgdal::checkCRSArgs(uprojargs)
+                    if (!res[[1]]) stop(res[[2]])
+                    uprojargs <- res[[2]]
+                }
+            }
         } else stop("rgdal version mismatch")
     }
     res <- new("CRS", projargs=uprojargs)


### PR DESCRIPTION
I found that with PROJ 520/GDAL 244, `CRS()` went down the wrong logic branch for NG **rgdal**. This PR now reverts to using the old code with new **sp**/**rgdal** and old PROJ/GDAL.