### PR TITLE
add options - rgdal_show_exportToProj4_warnings - all/thin/none to sp

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: sp
-Version: 1.4-2
+Version: 1.4-3
 Title: Classes and Methods for Spatial Data
 Authors@R: c(person("Edzer", "Pebesma", role = c("aut", "cre"),
 				email = "edzer.pebesma@uni-muenster.de"),

--- a/R/AAA.R
+++ b/R/AAA.R
@@ -8,5 +8,33 @@ assign("ReplCRS_warn", TRUE, envir = .spOptions)
 assign("Polypath", TRUE, envir = .spOptions)
 assign("PolypathRule", "winding", envir = .spOptions)
 assign("col.regions", bpy.colors(), envir = .spOptions)
+assign("thin_PROJ6_warnings", FALSE, envir=.spOptions)
+assign("PROJ6_warnings_count", 0L, envir=.spOptions)
+
+.onLoad <- function(lib, pkg) {
+  load_stuff()
+}
+
+load_stuff <- function() {
+  rgdal_show_exportToProj4_warnings <- options("rgdal_show_exportToProj4_warnings")
+  if (!is.null(rgdal_show_exportToProj4_warnings)) {
+    if (!(rgdal_show_exportToProj4_warnings %in% c("all", "thin", "none"))) {
+# CURRENT DEFAULT: "all"
+      rgdal_show_exportToProj4_warnings <- "all"
+    }
+  } else {
+# CURRENT DEFAULT: "all"
+    rgdal_show_exportToProj4_warnings <- "all"
+  }
+  if (rgdal_show_exportToProj4_warnings == "all") {
+    assign("rgdal_show_exportToProj4_warnings", TRUE, envir=.spOptions)
+  } else if (rgdal_show_exportToProj4_warnings == "thin") {
+    assign("rgdal_show_exportToProj4_warnings", TRUE, envir=.spOptions)
+    assign("thin_PROJ6_warnings", TRUE, envir=.spOptions)
+  } else {
+    assign("rgdal_show_exportToProj4_warnings", FALSE, envir=.spOptions)
+  }
+}
+
 .onUnload <- function(libpath)
     library.dynam.unload("sp", libpath)

--- a/R/CRS-methods.R
+++ b/R/CRS-methods.R
@@ -102,7 +102,7 @@ setMethod("wkt", signature(obj = "CRS"),
                     } else {
                       if (get("PROJ6_warnings_count",
                         envir=.spOptions) == 0L) {
-                        warning("CRS object has no comment")
+                        warning("CRS object has no comment\n repeated warnings suppressed")
                       }
                       assign("PROJ6_warnings_count",
                         get("PROJ6_warnings_count",

--- a/R/CRS-methods.R
+++ b/R/CRS-methods.R
@@ -94,8 +94,22 @@ if (!isGeneric("wkt"))
 setMethod("wkt", signature(obj = "CRS"),
 	function(obj) {
                 comm <- comment(obj)
-                if (is.null(comm))
-                    warning("CRS object has no comment")
+                if (is.null(comm)) {
+                  if (get("rgdal_show_exportToProj4_warnings",
+                    envir=.spOptions)) {
+                    if (!get("thin_PROJ6_warnings", envir=.spOptions)) {
+                      warning("CRS object has no comment")
+                    } else {
+                      if (get("PROJ6_warnings_count",
+                        envir=.spOptions) == 0L) {
+                        warning("CRS object has no comment")
+                      }
+                      assign("PROJ6_warnings_count",
+                        get("PROJ6_warnings_count",
+                        envir=.spOptions) + 1L, envir=.spOptions)
+                   }
+                 }
+                }
 		comm
         }
 )

--- a/R/projected.R
+++ b/R/projected.R
@@ -1,7 +1,20 @@
 setMethod("proj4string", signature(obj = "Spatial"),
 	function(obj) {
                 if (!is.null(comment(slot(obj, "proj4string"))))
-                    warning("CRS object has comment, which is lost in output")
+                  if (get("rgdal_show_exportToProj4_warnings",
+                    envir=.spOptions)) {
+                    if (!get("thin_PROJ6_warnings", envir=.spOptions)) {
+                      warning("CRS object has comment, which is lost in output")
+                    } else {
+                      if (get("PROJ6_warnings_count",
+                        envir=.spOptions) == 0L) {
+                        warning("CRS object has comment, which is lost in output")
+                      }
+                      assign("PROJ6_warnings_count",
+                        get("PROJ6_warnings_count",
+                        envir=.spOptions) + 1L, envir=.spOptions)
+                   }
+                 }
 		res <- as.character(obj@proj4string@projargs)
                 res
         }
@@ -10,8 +23,22 @@ setMethod("proj4string", signature(obj = "Spatial"),
 setMethod("wkt", signature(obj = "Spatial"),
 	function(obj) {
                 comm <- comment(slot(obj, "proj4string"))
-                if (is.null(comm))
-                    warning("CRS object has no comment")
+                if (is.null(comm)) {
+                  if (get("rgdal_show_exportToProj4_warnings",
+                    envir=.spOptions)) {
+                    if (!get("thin_PROJ6_warnings", envir=.spOptions)) {
+                      warning("CRS object has no comment")
+                    } else {
+                      if (get("PROJ6_warnings_count",
+                        envir=.spOptions) == 0L) {
+                        warning("CRS object has no comment")
+                      }
+                      assign("PROJ6_warnings_count",
+                        get("PROJ6_warnings_count",
+                        envir=.spOptions) + 1L, envir=.spOptions)
+                   }
+                 }
+                }
 		comm
         }
 )

--- a/R/projected.R
+++ b/R/projected.R
@@ -8,7 +8,7 @@ setMethod("proj4string", signature(obj = "Spatial"),
                     } else {
                       if (get("PROJ6_warnings_count",
                         envir=.spOptions) == 0L) {
-                        warning("CRS object has comment, which is lost in output")
+                        warning("CRS object has comment, which is lost in output\n repeated warnings suppressed")
                       }
                       assign("PROJ6_warnings_count",
                         get("PROJ6_warnings_count",
@@ -31,7 +31,7 @@ setMethod("wkt", signature(obj = "Spatial"),
                     } else {
                       if (get("PROJ6_warnings_count",
                         envir=.spOptions) == 0L) {
-                        warning("CRS object has no comment")
+                        warning("CRS object has no comment\n repeated warnings suppressed")
                       }
                       assign("PROJ6_warnings_count",
                         get("PROJ6_warnings_count",


### PR DESCRIPTION
Set up and implant framework for thinning and muting CRS-based warnings by using `options("rgdal_show_exportToProj4_warnings"="all")` before loading **sp** and **rgdal**, say in `.Rprofile`. Already present in **rgdal** 1.5-8. This edit adds the same treatment to **sp**. If no option, all warnings shown by default in current minor version of **sp** and **rgdal**, no warnings in next minor version. Valid values of option: `c("all", "thin", "none")`, where `"all"` is all CRS-based warnings, `"thin"` is show the first warning, and keep a hidden count of suppressed warnings, `"none"` show no CRS-based warnings.