### PR TITLE
fix URLs

### DIFF
--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -39,7 +39,7 @@
   \itemize{
 	\item update sp gallery, see \url{https://edzer.github.io/sp/}
 	\item move \code{methods} from Imports: to Depends:
-    \item improve base plot methods for \code{SpatialGridDataFrame} and \code{SpatialPixelsDataFrame} objects, see \url{http://r-spatial.org/r/2016/03/08/plotting-spatial-grids.html} for examples
+    \item improve base plot methods for \code{SpatialGridDataFrame} and \code{SpatialPixelsDataFrame} objects, see \url{https://www.r-spatial.org/r/2016/03/08/plotting-spatial-grids.html} for examples
 	\item improve the graticule \code{labels} methods, see \code{?gridlines}
 	\item fix hole assignment for triangles, reported in \url{https://stat.ethz.ch/pipermail/r-sig-geo/2016-March/024214.html}
     \item \code{as.SpatialPolygons.GridTopology} drops rownames of coordinates generated, but keeps coordinate (column) names from the \code{cellcentre.offset} slot of the grid

--- a/man/00sp.Rd
+++ b/man/00sp.Rd
@@ -89,9 +89,9 @@ spatial information with attribute data.
 }
 
 \section{References}{
-PROJ.4: \url{https://github.com/OSGeo/proj.4}
+PROJ.4: \url{https://github.com/OSGeo/PROJ}
 
-GDAL and OGR: \url{http://www.gdal.org/}.
+GDAL and OGR: \url{https://gdal.org/}.
 }
 
 \section{Authors}{

--- a/man/CRS-class.Rd
+++ b/man/CRS-class.Rd
@@ -51,7 +51,7 @@ whether \code{x} and \code{y} have identical CRS, or if \code{y}
 is missing whether all objects in list \code{x}
 have identical CRS.
 }
-\references{\url{https://github.com/OSGeo/proj.4}}
+\references{\url{https://github.com/OSGeo/PROJ}}
 \author{Roger Bivand \email{Roger.Bivand@nhh.no}}
 
 \note{

--- a/man/SpatialGridDataFrame-class.Rd
+++ b/man/SpatialGridDataFrame-class.Rd
@@ -90,7 +90,7 @@ value such as \code{1/6} to specify relative size; default \code{lcm(2.8)}}
   and \code{\link{SpatialPixelsDataFrame-class} which holds possibly incomplete
   grids }
 
-  Plotting gridded data with sp: \url{http://r-spatial.org/r/2016/03/08/plotting-spatial-grids.html}
+  Plotting gridded data with sp: \url{https://www.r-spatial.org/r/2016/03/08/plotting-spatial-grids.html}
 }
 \examples{
 data(meuse.grid) # only the non-missing valued cells


### PR DESCRIPTION
Have fixed URLs shown as stale/forwarded by check with R-devel and `_R_CHECK_CRAN_INCOMING_REMOTE_=TRUE _R_CHECK_CRAN_INCOMING_=TRUE`. One NOTE:
```
* checking dependencies in R code ... NOTE
Missing or unexported object: ‘rgdal::OSRIsProjected’
```
to be resolved with **rgdal** when released. Checked OK with released **rgdal** and trunk **rgdal**.