### PR TITLE
fix #92

### DIFF
--- a/R/SpatialLines-methods.R
+++ b/R/SpatialLines-methods.R
@@ -267,7 +267,7 @@ SpatialLines2SpatialPointsDataFrame = function(from) {
 	L3 = rep(1:length(from@lines), times = sapply(L, length))
 	L = unlist(L)
 	SpatialPointsDataFrame(spp, data.frame(Lines.NR = L3, Lines.ID=L2, 
-		Line.NR=L), proj4string=rebuild_CRS(slot(from, "proj4string")))
+		Line.NR=L))
 }
 setAs("SpatialLines", "SpatialPointsDataFrame", function(from)
 	SpatialLines2SpatialPointsDataFrame(from)


### PR DESCRIPTION
`spp` is "SpatialPoints", so the `proj4string` argument is ignored anyway
(and produces a warning since 9101ce27f552a33f1cffa04ddf13a5a820e90fb0)