### PR TITLE
fix partially matched argument names

### DIFF
--- a/R/bpy.colors.R
+++ b/R/bpy.colors.R
@@ -7,7 +7,7 @@ function (n = 100, cutoff.tails = 0.1, alpha = 1)
 
 	if (cutoff.tails >= 1 || cutoff.tails < 0)
 		stop("cutoff.tails should be in [0, 1]")
-	i = seq(0.5 * cutoff.tails, 1 - 0.5 * cutoff.tails, length = n)
+	i = seq(0.5 * cutoff.tails, 1 - 0.5 * cutoff.tails, length.out = n)
     r = ifelse(i < .25, 0, ifelse(i < .57, i / .32 - .78125, 1))
     g = ifelse(i < .42, 0, ifelse(i < .92, 2 * i - .84, 1))
     b = ifelse(i < .25, 4 * i, ifelse(i < .42, 1,

--- a/R/spplot.R
+++ b/R/spplot.R
@@ -389,7 +389,7 @@ function (x, y, z, subscripts, at = pretty(z), shrink, labels = NULL,
 	numcol <- length(at) - 1
 	numcol.r <- length(col.regions)
 	col.regions <- if (numcol.r <= numcol) 
-   			rep(col.regions, length = numcol)
+			rep_len(col.regions, numcol)
    		else col.regions[floor(1 + (1:numcol - 1) * (numcol.r - 1)/(numcol - 1))]
 	zcol <- rep(NA, length(z))
 	for (i in seq_along(col.regions)) zcol[!is.na(x) & !is.na(y) & 
@@ -491,7 +491,7 @@ SpatialPolygonsRescale = function(obj, offset, scale = 1, fill = "black", col = 
 		scale = rep(scale,2)
 	pls = slot(obj, "polygons")
    	pO = slot(obj, "plotOrder")
-	fill = rep(fill, length = length(pls))
+	fill = rep_len(fill, length(pls))
    	for (i in pO) {
    		Srs <- slot(pls[[i]], "Polygons")
    		pOi <- slot(pls[[i]], "plotOrder")
@@ -689,7 +689,7 @@ function (lst, z, ..., cuts = ifelse(identical(FALSE, colorkey), 5, 100),
                   max(lz[valid]), length = cuts + 1))[2:(cuts)], 
                   max(z[valid]))
             }
-            else cuts = seq(min(z[valid]), max(z[valid]), length = cuts + 
+            else cuts = seq(min(z[valid]), max(z[valid]), length.out = cuts +
                 1)
         }
         groups = cut(as.matrix(z), cuts, dig.lab = 4, include.lowest = TRUE)


### PR DESCRIPTION
A trivial fix to avoid numerous warnings of the form

```
10: In rep(fill, length = length(pls)) :
  partial argument match of 'length' to 'length.out'
```

when running `spplot()` (e.g., `example(spplot)`) under `options(warnPartialMatchArgs = TRUE)`.

`rep_len` can be used as a replacement because **sp** depends on R >= 3.0.0 anyway (where `rep_len` was introduced).