### PR TITLE
preserve SF comment in "[" for SpatialPolygons*

### DIFF
--- a/R/SpatialPolygons-methods.R
+++ b/R/SpatialPolygons-methods.R
@@ -130,8 +130,11 @@ setMethod("[", "SpatialPolygons", function(x, i, j, ..., drop = TRUE) {
 		x@plotOrder = integer(0)
 		stopifnot(validObject(x))
 		x
-	} else
-		SpatialPolygons(x@polygons[i], proj4string=rebuild_CRS(slot(x, "proj4string")))
+	} else {
+		y = SpatialPolygons(x@polygons[i], proj4string=rebuild_CRS(slot(x, "proj4string")))
+                if (!is.null(comment(x))) comment(y) <- comment(x)
+                y
+        }
 #	x@polygons = x@polygons[i]
 #	x@bbox <- .bboxCalcR(x@polygons)
 #	area <- sapply(slot(x, "polygons"), function(i) slot(i, "area"))

--- a/R/SpatialPolygonsDataFrame-methods.R
+++ b/R/SpatialPolygonsDataFrame-methods.R
@@ -120,6 +120,7 @@ setMethod("[", "SpatialPolygonsDataFrame", function(x, i, j, ... , drop = TRUE) 
             }
 	} else
 	    y@bbox = x@bbox
+        if (!is.null(comment(x))) comment(y) <- comment(x)
 	y
 ###
 ### RSB: do something with labelpoints here? How can I check they are present?


### PR DESCRIPTION
BDRs revdep for FlexScan showed that the simple-features comment on an sp polygons object was lost when subsetting, and this was needed to avoid `sf::st_as_sfc()` calling `rgeos::createSPComment()`. Please check that this makes sense.