### PR TITLE
Sprintf

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: sp
-Version: 1.5-1
+Version: 1.5-2
 Title: Classes and Methods for Spatial Data
 Authors@R: c(person("Edzer", "Pebesma", role = c("aut", "cre"),
 				email = "edzer.pebesma@uni-muenster.de"),

--- a/R/AAA.R
+++ b/R/AAA.R
@@ -47,7 +47,8 @@ load_stuff <- function() {
   } else {
     evolution_status <- Sys.getenv("_SP_EVOLUTION_STATUS_")
     if (nchar(evolution_status) > 0L) {
-      stopifnot(is.integer(as.integer(evolution_status)))
+      evolution_status <- as.integer(evolution_status)
+      stopifnot(is.integer(evolution_status))
       stopifnot(evolution_status >= 0L && evolution_status <= 2L)
       assign("evolution_status", unname(evolution_status), envir=.spOptions)
     }

--- a/R/AAA.R
+++ b/R/AAA.R
@@ -41,7 +41,8 @@ load_stuff <- function() {
   }
   evolution_status <- unlist(options("sp_evolution_status"))
   if (!is.null(evolution_status)) {
-    stopifnot(is.integer(as.integer(evolution_status)))
+    evolution_status <- as.integer(evolution_status)
+    stopifnot(is.integer(evolution_status))
     stopifnot(evolution_status >= 0L && evolution_status <= 2L)
     assign("evolution_status", unname(evolution_status), envir=.spOptions)
   } else {

--- a/inst/include/sp.h
+++ b/inst/include/sp.h
@@ -8,7 +8,7 @@
 #endif
 /* remember to touch local_stubs.c */
 
-#define SP_VERSION "1.5-1"
+#define SP_VERSION "1.5-2"
 
 #include <R.h>
 /* RSB 091203 */

--- a/inst/include/sp_xports.c
+++ b/inst/include/sp_xports.c
@@ -657,9 +657,9 @@ void SP_PREFIX(comm2comment)(char *buf, int bufsiz, int *comm, int nps) {
     nc1 = (nc*nps)+1;
     if (bufsiz < nc1) error("comm2comment: buffer overflow");
 
-    sprintf(buf, "%d", comm[0]);
+    snprintf(buf, sizeof(buf), "%d", comm[0]);
     for (i=1; i<nps; i++) {
-        sprintf(cbuf, " %d", comm[i]);
+        snprintf(cbuf, sizeof(cbuf), " %d", comm[i]);
         if (strlen(buf) + strlen(cbuf) >= bufsiz)
             error("comm2comment: buffer overflow");
         strcat(buf, cbuf);

--- a/man/aggregate.Rd
+++ b/man/aggregate.Rd
@@ -31,7 +31,7 @@ or by attribute values, using aggregation function \code{FUN}.
 If \code{areaWeighted} is \code{TRUE}, \code{FUN} is ignored and the
 area weighted mean is computed for numerical variables, or if all
 attributes are \code{factor}s, the area dominant factor level (area
-mode) is returned. This will compute the \link[rgeos:topo-bin-gIntersection]{gIntersection}
+mode) is returned. This will compute the \link[rgeos:rgeos-deprecated]{gIntersection}
 of \code{x} and \code{by}; see examples below.
 
 If \code{by} is missing, aggregates over all features.

--- a/src/sp.h
+++ b/src/sp.h
@@ -8,7 +8,7 @@
 #endif
 /* remember to touch local_stubs.c */
 
-#define SP_VERSION "1.5-1"
+#define SP_VERSION "1.5-2"
 
 #include <R.h>
 /* RSB 091203 */

--- a/src/sp_xports.c
+++ b/src/sp_xports.c
@@ -657,9 +657,9 @@ void SP_PREFIX(comm2comment)(char *buf, int bufsiz, int *comm, int nps) {
     nc1 = (nc*nps)+1;
     if (bufsiz < nc1) error("comm2comment: buffer overflow");
 
-    sprintf(buf, "%d", comm[0]);
+    snprintf(buf, sizeof(buf), "%d", comm[0]);
     for (i=1; i<nps; i++) {
-        sprintf(cbuf, " %d", comm[i]);
+        snprintf(cbuf, sizeof(cbuf), " %d", comm[i]);
         if (strlen(buf) + strlen(cbuf) >= bufsiz)
             error("comm2comment: buffer overflow");
         strcat(buf, cbuf);


### PR DESCRIPTION
CRAN is showing warnings related to `sprintf` for **sp**, **rgdal** and **rgeos** - the latter two link to **sp**. Fixes are `snprintf(buf, sizeof(buf), ...)`, and work with current R-devel (F37 built locally).