### PR TITLE
Internalise status

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: sp
-Version: 1.5-1
+Version: 1.5-2
 Title: Classes and Methods for Spatial Data
 Authors@R: c(person("Edzer", "Pebesma", role = c("aut", "cre"),
 				email = "edzer.pebesma@uni-muenster.de"),

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -59,6 +59,8 @@ export(
 	set_PolypathRule,
 	set_col_regions,
 	get_col_regions,
+	set_evolution_status,
+	get_evolution_status,
 
 	coordinatevalues,
 

--- a/R/CRS-methods.R
+++ b/R/CRS-methods.R
@@ -23,7 +23,7 @@ setMethod("rebuild_CRS", signature(obj = "CRS"),
 
 
 "CRS" <- function(projargs=NA_character_, doCheckCRSArgs=TRUE,
-    SRS_string=NULL, get_source_if_boundcrs=TRUE) {
+    SRS_string=NULL, get_source_if_boundcrs=TRUE, use_cache=TRUE) {
 # cautious change BDR 150424
 # trap NULL too 200225
     if (is.null(projargs))
@@ -37,7 +37,7 @@ setMethod("rebuild_CRS", signature(obj = "CRS"),
     stopifnot(is.character(projargs))
 #    CRS_CACHE <- get("CRS_CACHE", envir=.sp_CRS_cache)
     input_projargs <- projargs
-    if (!is.na(input_projargs)) {
+    if (!is.na(input_projargs) && use_cache) {
         res <- .sp_CRS_cache[[input_projargs]]
         if (!is.null(res)) {
             return(res)

--- a/R/projected.R
+++ b/R/projected.R
@@ -112,7 +112,9 @@ setMethod("is.projected", signature(obj = "Spatial"), is.projectedSpatial)
 is.projectedCRS <- function(obj) {
 	p4str <- slot(obj, "projargs")
 	wkt2 <- comment(obj)
-	if (get("evolution_status", envir=.spOptions) == 2L) {
+	if (is.null(wkt2) && is.na(p4str))
+		as.logical(NA)
+	else if (get("evolution_status", envir=.spOptions) == 2L) {
 		if (!requireNamespace("sf", quietly = TRUE))
 			stop("sf required for evolution_status==2L")
 		o <- try(sf::st_is_longlat(obj), silent=TRUE)
@@ -121,9 +123,7 @@ is.projectedCRS <- function(obj) {
                     length(grep("longlat", p4str, fixed = TRUE)) == 0L
                 else
                     !o
-	} else if (is.null(wkt2) && is.na(p4str))
-		as.logical(NA)
-	else if (get("evolution_status", envir=.spOptions) == 0L && 
+	} else if (get("evolution_status", envir=.spOptions) == 0L && 
 			requireNamespace("rgdal", quietly = TRUE) &&
 			packageVersion("rgdal") >= "1.5.17" && rgdal::new_proj_and_gdal())
 		rgdal::OSRIsProjected(obj)

--- a/R/spOptions.R
+++ b/R/spOptions.R
@@ -67,3 +67,17 @@ set_col_regions <- function(value) {
 get_col_regions <- function() {
 	    get("col.regions", envir = .spOptions)
 }
+
+set_evolution_status <- function(value) {
+        stopifnot(is.integer(value))
+        stopifnot(length(value) == 1)
+	    assign("evolution_status", value, envir = .spOptions)
+                get_evolution_status()
+}
+
+get_evolution_status  <- function() {
+	    get("evolution_status", envir = .spOptions)
+}
+
+
+

--- a/man/CRS-class.Rd
+++ b/man/CRS-class.Rd
@@ -32,7 +32,8 @@ Objects can be created by calls of the form \code{CRS("projargs")}, where "proja
   }
 }
 \usage{
-CRS(projargs, doCheckCRSArgs=TRUE, SRS_string=NULL, get_source_if_boundcrs=TRUE)
+CRS(projargs, doCheckCRSArgs=TRUE, SRS_string=NULL, get_source_if_boundcrs=TRUE,
+ use_cache=TRUE)
 identicalCRS(x,y)
 }
 \arguments{
@@ -40,6 +41,7 @@ identicalCRS(x,y)
 \item{doCheckCRSArgs}{default TRUE, must be set to FALSE by package developers including \code{CRS} in an S4 class definition to avoid uncontrollable loading of the \pkg{rgdal} namespace}
 \item{SRS_string}{default NULL, only used when \pkg{rgdal} is built with PROJ >= 6 and GDAL >= 3; a valid WKT string or SRS definition such as \code{"EPSG:4326"} or \code{"ESRI:102761"}}
 \item{get_source_if_boundcrs}{(from \pkg{rgdal} 1.5-17, default TRUE) The presence of the \code{+towgs84=} key in a Proj4 string \code{projargs=} argument value may promote the output WKT2 CRS to BOUNDCRS for PROJ >= 6 and GDAL >= 3, which is a coordinate operation from the input datum to WGS84. This is often unfortunate, so a PROJ function is called through \pkg{rgdal} to retrieve the underlying source definition.}
+\item{use_cache}{default TRUE, if FALSE ignore cached lookup values}
 \item{x}{object having a \link{proj4string} method,
 or if \code{y} is missing, list with objects that have a \code{proj4string} method}
 \item{y}{object of class \link{Spatial}, or having a \link{proj4string} method}

--- a/man/spTransform.Rd
+++ b/man/spTransform.Rd
@@ -4,16 +4,22 @@
 \alias{spTransform,Spatial,character-method}
 \alias{spTransform,Spatial,ANY-method}
 \alias{spTransform}
+\alias{get_evolution_status}
+\alias{set_evolution_status}
+
 \title{ spTransform for map projection and datum transformation }
 \description{ spTransform for map projection and datum transformation }
 \usage{
 spTransform(x, CRSobj, ...)
+set_evolution_status(value)
+get_evolution_status()
 }
 \arguments{
 \item{x}{ object to be transformed }
 \item{CRSobj}{ object of class \link{CRS}, or of class \code{character} in
 which case it is converted to \link{CRS}}
 \item{...}{further arguments (ignored) }
+\item{value}{evolution status: 0L business as usual, 1L no retiring packages, 2L use sf functions in place of rgdal}
 }
 \value{
 object with coordinates transformed to the new coordinate reference


### PR DESCRIPTION
Adding exported access to setting evolution status within a running session, and adding an argument to `CRS()` to turn off reading the cache. See "Handling "CRS" objects from the sp package when rgdal has retired" in https://rsbivand.github.io/csds_jan23/csds_crs_workshop_230119.html#Representing_CRS_in_R_packages