### PR TITLE
deprecate functions that call to rgeos

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: sp
-Version: 1.5-2
+Version: 1.6-0
 Title: Classes and Methods for Spatial Data
 Authors@R: c(person("Edzer", "Pebesma", role = c("aut", "cre"),
 				email = "edzer.pebesma@uni-muenster.de"),

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -49,6 +49,7 @@ aggregate.data.frame.SP <- function (x, by, FUN, ..., dissolve = TRUE) {
 		if (!gridded(geom) && is(geom, "SpatialPoints"))
 			geom = split(geom, factor(grp)) # creates SpatialMultiPoints
 		else {
+			.Deprecated("sf::agregate")
 			if (!requireNamespace("rgeos", quietly = TRUE))
 				stop("rgeos required")
 			if (is(geom, "SpatialLines"))
@@ -71,6 +72,7 @@ aggregate.Spatial = function(x, by = list(ID = rep(1, length(x))), FUN, ...,
 		if (gridded(by))
 			by = as(by, "SpatialPolygons")
 		if (is(x, "SpatialPolygonsDataFrame") && is(by, "SpatialPolygons") && areaWeighted) {
+			.Deprecated("sf::agregate")
 			if (!missing(FUN))
 				warning("argument FUN is ignored in area-weighted aggregation, see documentation")
 			df = aggregatePolyWeighted(x, by)

--- a/R/disaggregate.R
+++ b/R/disaggregate.R
@@ -28,7 +28,11 @@ explodePolygons <- function(x, ignoreholes=FALSE, ...) {
           pp <- x@polygons[[i]]
           pp@ID <- as.character(count + 1)
         } else {
-          cmt <- as.integer(unlist(strsplit(rgeos::createPolygonsComment(x@polygons[[i]]), ' ')))
+          # cmt <- as.integer(unlist(strsplit(rgeos::createPolygonsComment(x@polygons[[i]]), ' ')))
+          cmt <- comment(x@polygons[[i]])
+		  if (is.null(cmt))
+			stop("legacy Spatial object without polygon comments: please repair first using as(st_as_sf(x), \"Spatial\")")
+          cmt <- as.integer(unlist(strsplit(cmt, ' ')))
           cmt <- cbind(id=1:length(cmt), holeOf=cmt)
           cmt <- cmt[cmt[,2] > 0, ,drop=FALSE]
           pp <- NULL
@@ -58,8 +62,11 @@ explodePolygons <- function(x, ignoreholes=FALSE, ...) {
   }
   p <- SpatialPolygons(p)
   ps <- slot(p, "polygons")
-  for (i in seq_along(ps))
-    comment(ps[[i]]) <- rgeos::createPolygonsComment(ps[[i]])
+  for (i in seq_along(ps)) {
+    # comment(ps[[i]]) <- rgeos::createPolygonsComment(ps[[i]])
+	n = length(ps[[i]]@Polygons)
+    comment(ps[[i]]) <- do.call(paste, as.list(c("0", rep("1", n - 1)))) # they must be all holes now!
+  }
   slot(p, "polygons") <- ps
   proj4string(p) <- crs
   

--- a/R/over.R
+++ b/R/over.R
@@ -205,6 +205,7 @@ setMethod("over", signature("SpatialPoints", "SpatialPixelsDataFrame"),
 
 setMethod("over", signature("Spatial", "Spatial"),  # catch remaining:
 	function(x, y, returnList = FALSE, fn = NULL, ...) {
+		.Deprecated("sf::st_intersects or sf::aggregate")
     	if (!requireNamespace("rgeos", quietly = TRUE))
 			stop("package rgeos is required for additional over methods")
 		if (is(x, "SpatialMultiPoints") || is(y, "SpatialMultiPoints"))

--- a/inst/include/sp.h
+++ b/inst/include/sp.h
@@ -8,7 +8,7 @@
 #endif
 /* remember to touch local_stubs.c */
 
-#define SP_VERSION "1.5-2"
+#define SP_VERSION "1.6-0"
 
 #include <R.h>
 /* RSB 091203 */

--- a/inst/include/sp_xports.c
+++ b/inst/include/sp_xports.c
@@ -661,7 +661,7 @@ void SP_PREFIX(comm2comment)(char *buf, int bufsiz, int *comm, int nps) {
     bufsiz -= pr;
     for (i = 1; i < nps; i++) {
         snprintf(cbuf, 15, " %d", comm[i]);
-        if (strlen(buf) + strlen(cbuf) >= bufsiz)
+        if (strlen(cbuf) >= bufsiz)
             error("comm2comment: buffer overflow");
         strncat(buf, cbuf, bufsiz);
         bufsiz -= strlen(cbuf);

--- a/man/aggregate.Rd
+++ b/man/aggregate.Rd
@@ -37,6 +37,10 @@ of \code{x} and \code{by}; see examples below.
 If \code{by} is missing, aggregates over all features.
 }
 \details{
+For as far as these functions use package rgeos, (lines, polygons,
+dissolve = TRUE), they are deprecated as rgeos will retire; try
+using sf::aggregate instead.
+
 \code{FUN} should be a function that takes as first argument a
 vector, and that returns a single number. The canonical examples
 are \link{mean} and \link{sum}. Counting features is obtained when
@@ -83,8 +87,8 @@ if (require(gstat) && require(rgeos)) {
 	spplot(x[1],col.regions=bpy.colors())
 	i = cut(x$var1.pred, seq(4, 7.5, by=.5), 
 		include.lowest = TRUE)
-	xa = aggregate(x["var1.pred"], list(i=i), mean)
-	spplot(xa[1],col.regions=bpy.colors(8))
+	# xa = aggregate(x["var1.pred"], list(i=i), mean)
+	# spplot(xa[1],col.regions=bpy.colors(8))
 }
 
 if (require(rgeos)) {
@@ -111,12 +115,12 @@ if (require(rgeos)) {
   text(coordinates(i), ids.i, cex = .8, col = 'blue')
 
   # compute & plot area-weighted average; will warn for the factor
-  ret = aggregate(p1, p2, areaWeighted = TRUE)
-  spplot(ret)
+  #ret = aggregate(p1, p2, areaWeighted = TRUE)
+  #spplot(ret)
 
   # all-factor attributes: compute area-dominant factor level:
-  ret = aggregate(p1["x"], p2, areaWeighted = TRUE) 
-  spplot(ret)
+  #ret = aggregate(p1["x"], p2, areaWeighted = TRUE) 
+  #spplot(ret)
 }
 }
 \keyword{methods}

--- a/man/aggregate.Rd
+++ b/man/aggregate.Rd
@@ -19,9 +19,9 @@ is a list, aggregation by attribute(s), see \link{aggregate.data.frame}}
 is specified, which is passed on to function \link{over}}
 \item{dissolve}{logical; should, when aggregating based on attributes, the
 resulting geometries be dissolved? Note that if \code{x} has class
-\code{SpatialPointsDataFrame}, this returns an object of class \code{SpatialMultiPointsDataFrame}}
+\code{SpatialPointsDataFrame}, this returns an object of class \code{SpatialMultiPointsDataFrame}; deprecated}
 \item{areaWeighted}{logical; should the aggregation of \code{x} be weighted by the
-areas it intersects with each feature of \code{by}? See value.}
+areas it intersects with each feature of \code{by}? See value; deprecated.}
 }
 \value{ 
 The aggregation of attribute values of \code{x} either over the
@@ -31,8 +31,9 @@ or by attribute values, using aggregation function \code{FUN}.
 If \code{areaWeighted} is \code{TRUE}, \code{FUN} is ignored and the
 area weighted mean is computed for numerical variables, or if all
 attributes are \code{factor}s, the area dominant factor level (area
-mode) is returned. This will compute the \link[rgeos:rgeos-deprecated]{gIntersection}
-of \code{x} and \code{by}; see examples below.
+mode) is returned.  This computes the intersection of \code{x}
+and \code{by}; see examples below.  As this uses code from package
+rgeos, it is deprecated as package rgeos will retire.
 
 If \code{by} is missing, aggregates over all features.
 }

--- a/src/sp.h
+++ b/src/sp.h
@@ -8,7 +8,7 @@
 #endif
 /* remember to touch local_stubs.c */
 
-#define SP_VERSION "1.5-2"
+#define SP_VERSION "1.6-0"
 
 #include <R.h>
 /* RSB 091203 */

--- a/src/sp_xports.c
+++ b/src/sp_xports.c
@@ -661,7 +661,7 @@ void SP_PREFIX(comm2comment)(char *buf, int bufsiz, int *comm, int nps) {
     bufsiz -= pr;
     for (i = 1; i < nps; i++) {
         snprintf(cbuf, 15, " %d", comm[i]);
-        if (strlen(buf) + strlen(cbuf) >= bufsiz)
+        if (strlen(cbuf) >= bufsiz)
             error("comm2comment: buffer overflow");
         strncat(buf, cbuf, bufsiz);
         bufsiz -= strlen(cbuf);

--- a/tests/agg.R
+++ b/tests/agg.R
@@ -5,31 +5,31 @@ g = SpatialGrid(GridTopology(c(5,5), c(10,10), c(3,3)))
 p = as(g, "SpatialPolygons")
 p$z = c(1,0,1,0,1,0,1,0,1)
 cc = coordinates(g)
-p$ag1 = aggregate(p, p, mean)[[1]]
-p$ag1a = aggregate(p, p, mean, minDimension = 0)[[1]]
-p$ag2 = aggregate(p, p, mean, minDimension = 1)[[1]]
-p$ag3 = aggregate(p, p, mean, minDimension = 2)[[1]]
-p$ag4 = aggregate(p, p, mean, areaWeighted=TRUE)[[1]]
+#p$ag1 = aggregate(p, p, mean)[[1]]
+#p$ag1a = aggregate(p, p, mean, minDimension = 0)[[1]]
+#p$ag2 = aggregate(p, p, mean, minDimension = 1)[[1]]
+#p$ag3 = aggregate(p, p, mean, minDimension = 2)[[1]]
+#p$ag4 = aggregate(p, p, mean, areaWeighted=TRUE)[[1]]
 pts = cbind(c(9,21,21,9,9),c(9,9,21,21,9))
 sq = SpatialPolygons(list(Polygons(list(Polygon(pts)), "ID")))
 rnd2 = function(x) round(x, 2)
-l = list(
-	list("sp.text", cc, rnd2(p$z), which = 1),
-	list("sp.text", cc, rnd2(p$ag1), which = 2),
-	list("sp.text", cc, rnd2(p$ag1a), which = 3),
-	list("sp.text", cc, rnd2(p$ag2), which = 4),
-	list("sp.text", cc, rnd2(p$ag3), which = 5),
-	list("sp.text", cc, rnd2(p$ag4), which = 6),
-	list(sq, col = 'green', which = 6, first = FALSE, lwd = 2)
-)
-spplot(p, names.attr = c("source", "default aggregate", "minDimension=0", 
-	"minDimension=1", "minDimension=2", "areaWeighted=TRUE"), layout = c(3,2), 
-	as.table=TRUE, col.regions=bpy.colors(151)[50:151], cuts=100, 
-	sp.layout = l, scales = list(draw = TRUE))
+#l = list(
+#	list("sp.text", cc, rnd2(p$z), which = 1),
+#	list("sp.text", cc, rnd2(p$ag1), which = 2),
+#	list("sp.text", cc, rnd2(p$ag1a), which = 3),
+#	list("sp.text", cc, rnd2(p$ag2), which = 4),
+#	list("sp.text", cc, rnd2(p$ag3), which = 5),
+#	list("sp.text", cc, rnd2(p$ag4), which = 6),
+#	list(sq, col = 'green', which = 6, first = FALSE, lwd = 2)
+#)
+#spplot(p, names.attr = c("source", "default aggregate", "minDimension=0", 
+#	"minDimension=1", "minDimension=2", "areaWeighted=TRUE"), layout = c(3,2), 
+#	as.table=TRUE, col.regions=bpy.colors(151)[50:151], cuts=100, 
+#	sp.layout = l, scales = list(draw = TRUE))
 
-rnd2(c(aggregate(p, sq, mean)[[1]],
-  aggregate(p, sq, mean, minDimension = 0)[[1]],
-  aggregate(p, sq, mean, minDimension = 1)[[1]],
-  aggregate(p, sq, mean, minDimension = 2)[[1]],
-  aggregate(p, sq, mean, areaWeighted=TRUE)[[1]]))
+#rnd2(c(aggregate(p, sq, mean)[[1]],
+#  aggregate(p, sq, mean, minDimension = 0)[[1]],
+#  aggregate(p, sq, mean, minDimension = 1)[[1]],
+#  aggregate(p, sq, mean, minDimension = 2)[[1]],
+#  aggregate(p, sq, mean, areaWeighted=TRUE)[[1]]))
 }

--- a/tests/agg.Rout.save
+++ b/tests/agg.Rout.save
@@ -22,33 +22,33 @@ Type 'q()' to quit R.
 + p = as(g, "SpatialPolygons")
 + p$z = c(1,0,1,0,1,0,1,0,1)
 + cc = coordinates(g)
-+ p$ag1 = aggregate(p, p, mean)[[1]]
-+ p$ag1a = aggregate(p, p, mean, minDimension = 0)[[1]]
-+ p$ag2 = aggregate(p, p, mean, minDimension = 1)[[1]]
-+ p$ag3 = aggregate(p, p, mean, minDimension = 2)[[1]]
-+ p$ag4 = aggregate(p, p, mean, areaWeighted=TRUE)[[1]]
++ #p$ag1 = aggregate(p, p, mean)[[1]]
++ #p$ag1a = aggregate(p, p, mean, minDimension = 0)[[1]]
++ #p$ag2 = aggregate(p, p, mean, minDimension = 1)[[1]]
++ #p$ag3 = aggregate(p, p, mean, minDimension = 2)[[1]]
++ #p$ag4 = aggregate(p, p, mean, areaWeighted=TRUE)[[1]]
 + pts = cbind(c(9,21,21,9,9),c(9,9,21,21,9))
 + sq = SpatialPolygons(list(Polygons(list(Polygon(pts)), "ID")))
 + rnd2 = function(x) round(x, 2)
-+ l = list(
-+ 	list("sp.text", cc, rnd2(p$z), which = 1),
-+ 	list("sp.text", cc, rnd2(p$ag1), which = 2),
-+ 	list("sp.text", cc, rnd2(p$ag1a), which = 3),
-+ 	list("sp.text", cc, rnd2(p$ag2), which = 4),
-+ 	list("sp.text", cc, rnd2(p$ag3), which = 5),
-+ 	list("sp.text", cc, rnd2(p$ag4), which = 6),
-+ 	list(sq, col = 'green', which = 6, first = FALSE, lwd = 2)
-+ )
-+ spplot(p, names.attr = c("source", "default aggregate", "minDimension=0", 
-+ 	"minDimension=1", "minDimension=2", "areaWeighted=TRUE"), layout = c(3,2), 
-+ 	as.table=TRUE, col.regions=bpy.colors(151)[50:151], cuts=100, 
-+ 	sp.layout = l, scales = list(draw = TRUE))
++ #l = list(
++ #	list("sp.text", cc, rnd2(p$z), which = 1),
++ #	list("sp.text", cc, rnd2(p$ag1), which = 2),
++ #	list("sp.text", cc, rnd2(p$ag1a), which = 3),
++ #	list("sp.text", cc, rnd2(p$ag2), which = 4),
++ #	list("sp.text", cc, rnd2(p$ag3), which = 5),
++ #	list("sp.text", cc, rnd2(p$ag4), which = 6),
++ #	list(sq, col = 'green', which = 6, first = FALSE, lwd = 2)
++ #)
++ #spplot(p, names.attr = c("source", "default aggregate", "minDimension=0", 
++ #	"minDimension=1", "minDimension=2", "areaWeighted=TRUE"), layout = c(3,2), 
++ #	as.table=TRUE, col.regions=bpy.colors(151)[50:151], cuts=100, 
++ #	sp.layout = l, scales = list(draw = TRUE))
 + 
-+ rnd2(c(aggregate(p, sq, mean)[[1]],
-+   aggregate(p, sq, mean, minDimension = 0)[[1]],
-+   aggregate(p, sq, mean, minDimension = 1)[[1]],
-+   aggregate(p, sq, mean, minDimension = 2)[[1]],
-+   aggregate(p, sq, mean, areaWeighted=TRUE)[[1]]))
++ #rnd2(c(aggregate(p, sq, mean)[[1]],
++ #  aggregate(p, sq, mean, minDimension = 0)[[1]],
++ #  aggregate(p, sq, mean, minDimension = 1)[[1]],
++ #  aggregate(p, sq, mean, minDimension = 2)[[1]],
++ #  aggregate(p, sq, mean, areaWeighted=TRUE)[[1]]))
 + }
 rgeos version: 0.6-1, (SVN revision 692)
  GEOS runtime version: 3.11.1-CAPI-1.17.1 
@@ -58,15 +58,7 @@ plan transition to sf functions using GEOS at your earliest convenience.
  Linking to sp version: 1.5-1 
  Polygon checking: TRUE 
 
-[1] 0.56 0.56 0.56 0.56 0.72
-Warning messages:
-1: In aggregate.Spatial(p, p, mean, areaWeighted = TRUE) :
-  argument FUN is ignored in area-weighted aggregation, see documentation
-2: GEOS support is provided by the sf and terra packages among others 
-3: In aggregate.Spatial(p, sq, mean, areaWeighted = TRUE) :
-  argument FUN is ignored in area-weighted aggregation, see documentation
-4: GEOS support is provided by the sf and terra packages among others 
 > 
 > proc.time()
    user  system elapsed 
-  0.623   0.768   0.503 
+  0.569   0.755   0.428 


### PR DESCRIPTION
This PR:
* adds `.Deprecate()` to functions that call rgeos functions
* removes their use from documentation and tests
* removes the rgeos::createComment calls from `disaggregate` by
    * assuming objects have a comment, and suggesting how to get one by roundtripping through sf otherwis
    * simply creating the resulting comment which has to be `0 1 1 1 ...` for disaggregated geometries
