### PR TITLE
Correct how is.na.CRS looks for the wkt comment

### DIFF
--- a/R/CRS-methods.R
+++ b/R/CRS-methods.R
@@ -249,5 +249,5 @@ identicalCRS1 = function(x, y) {
 }
 
 is.na.CRS = function(x) {
-	is.na(x@projargs) && is.null(comment(slot(x, "proj4string")))
+	is.na(x@projargs) && is.null(comment(x))
 }


### PR DESCRIPTION
Old version of is.na.CRS incorrectly looked for a proj4string slot in the CRS object to extract a wkt comment from, but should extract the wkt comment from a comment on the CRS object itself.
Discussed at
https://github.com/inlabru-org/inlabru/issues/178

```
> sp::set_evolution_status(2L)
[1] 2
inlabru:devel> is.na(sp::CRS("+proj=geocent +units=km"))
Error in slot(x, "proj4string") : 
  no slot of name "proj4string" for this object of class "CRS"

> sp:::is.na.CRS
function (x) 
{
    is.na(x@projargs) && is.null(comment(slot(x, "proj4string")))
}

# What I believe is the correct approach:
> x<-sp::CRS("+proj=geocent +units=km")
> is.na(x@projargs) && is.null(comment(x))
[1] FALSE
```