### PR TITLE
add check in CRS for evolution status 2 when both projargs and SRS_st…

### DIFF
--- a/R/CRS-methods.R
+++ b/R/CRS-methods.R
@@ -46,6 +46,8 @@ setMethod("rebuild_CRS", signature(obj = "CRS"),
     if (get("evolution_status", envir=.spOptions) > 0L) doCheckCRSArgs <- FALSE
     if (get("evolution_status", envir=.spOptions) == 2L) {
         if (requireNamespace("sf", quietly = TRUE)) {
+            if ((length(grep("^[ ]*\\+", projargs)) > 0L) &&
+                !is.null(SRS_string)) projargs <- NA_character_
             if ((is.na(projargs) && !is.null(SRS_string))) {
                 res <- sf::st_crs(SRS_string)
                 res <- as(res, "CRS")

--- a/R/SpatialMultiPoints-methods.R
+++ b/R/SpatialMultiPoints-methods.R
@@ -80,7 +80,7 @@ setAs("SpatialMultiPoints", "data.frame", function(from) as.data.frame(from))
 row.names.SpatialMultiPoints <- function(x) {
     ret = names(slot(x, "coords"))
 	if (is.null(ret))
-		ret = seq_len(slot(x, "coords"))
+		ret = seq_len(length(slot(x, "coords")))
 	ret
 }
 names.SpatialMultiPoints <- row.names.SpatialMultiPoints 


### PR DESCRIPTION
…ring given, prefer SRS_string. Came from revdeps for evolution status 2 and found that when `raster::,makeCRS()` provided both, `projargs` was prefered and led to a test failure (reading a .grd file didn't retrieve the written WKT2 string).