### PR TITLE
sp_2.0-0 draft changing to status `2L`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: sp
-Version: 1.6-1
+Version: 2.0-0
 Title: Classes and Methods for Spatial Data
 Authors@R: c(person("Edzer", "Pebesma", role = c("aut", "cre"),
 				email = "edzer.pebesma@uni-muenster.de"),
@@ -21,7 +21,11 @@ Description: Classes and methods for spatial
   data; the classes document where the spatial location information
   resides, for 2D or 3D data. Utility functions are provided, e.g. for
   plotting data as maps, spatial selection, as well as methods for
-  retrieving coordinates, for subsetting, print, summary, etc.
+  retrieving coordinates, for subsetting, print, summary, etc. From this
+  version, evolution status is set to '2L' using 'sf' in place of 'rgdal',
+  see <https://r-spatial.org/r/2023/05/15/evolution4.html> for details.
+  Retiring packages 'maptools', 'rgdal' and 'rgeos' will be dropped by
+  October 2023.
 License: GPL (>= 2)
 URL: https://github.com/edzer/sp/ https://edzer.github.io/sp/
 BugReports: https://github.com/edzer/sp/issues

--- a/R/AAA.R
+++ b/R/AAA.R
@@ -82,7 +82,7 @@ load_stuff <- function() {
 
 smess_func <- function() {
   where <- get("startup_message", envir=.spOptions)
-  Smess <- paste("The legacy packages maptools, rgdal, and rgeos, underpinning the sp package,\nwhich was just ", where, "ed, will retire in October 2023.\nPlease refer to R-spatial evolution reports for details, especially\nhttps://r-spatial.org/r/2023/05/15/evolution4.html.\nThe sp package is now running under evolution status ", get_evolution_status(), "\n", ifelse(get_evolution_status() == 2L, "     (status 2 uses the sf package in place of rgdal)\n", ""), sep="")
+  Smess <- paste("The legacy packages maptools, rgdal, and rgeos, underpinning the sp package,\nwhich was just ", where, "ed, will retire in October 2023.\nPlease refer to R-spatial evolution reports for details, especially\nhttps://r-spatial.org/r/2023/05/15/evolution4.html.\nIt may be desirable to make the sf package available;\npackage maintainers should consider adding sf to Suggests:.\nThe sp package is now running under evolution status ", get_evolution_status(), "\n", ifelse(get_evolution_status() == 2L, "     (status 2 uses the sf package in place of rgdal)\n", ""), sep="")
   packageStartupMessage(Smess, appendLF = FALSE)
 }
 

--- a/R/AAA.R
+++ b/R/AAA.R
@@ -10,7 +10,7 @@ assign("PolypathRule", "winding", envir = .spOptions)
 assign("col.regions", bpy.colors(), envir = .spOptions)
 assign("thin_PROJ6_warnings", FALSE, envir=.spOptions)
 assign("PROJ6_warnings_count", 0L, envir=.spOptions)
-assign("evolution_status", 0L, envir=.spOptions)
+assign("evolution_status", 2L, envir=.spOptions) # default changed 2.0-0
 
 #.sp_CRS_cache <- new.env(FALSE, globalenv())
 #assign("CRS_CACHE", list(), envir=.sp_CRS_cache)

--- a/R/CRS-methods.R
+++ b/R/CRS-methods.R
@@ -67,7 +67,8 @@ setMethod("rebuild_CRS", signature(obj = "CRS"),
             }
             return(res)
         } else {
-            warning("sf required for evolution_status==2L")
+            if (get("startup_message", envir=.spOptions) != "none")
+                warning("sf required for evolution_status==2L")
         }
     }
     if ((is.na(projargs) && !is.null(SRS_string)) && 

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -49,6 +49,7 @@ aggregate.data.frame.SP <- function (x, by, FUN, ..., dissolve = TRUE) {
 		if (!gridded(geom) && is(geom, "SpatialPoints"))
 			geom = split(geom, factor(grp)) # creates SpatialMultiPoints
 		else {
+                        warning("No rgeos support in sp from October 2023;\nsee https://r-spatial.org/r/2023/05/15/evolution4.html")
 			.Deprecated("sf::agregate")
 			if (!requireNamespace("rgeos", quietly = TRUE))
 				stop("rgeos required")
@@ -86,6 +87,7 @@ aggregate.Spatial = function(x, by = list(ID = rep(1, length(x))), FUN, ...,
 }
 
 aggregatePolyWeighted = function(x, by) {
+        warning("No rgeos support in sp from October 2023;\nsee https://r-spatial.org/r/2023/05/15/evolution4.html")
 	if (!requireNamespace("rgeos", quietly = TRUE))
 		stop("rgeos required")
 	i = rgeos::gIntersection(x, by, byid = TRUE, drop_lower_td = TRUE)

--- a/R/disaggregate.R
+++ b/R/disaggregate.R
@@ -7,6 +7,7 @@ if (!isGeneric("disaggregate")) {
 
 # Robert Hijmans:
 explodePolygons <- function(x, ignoreholes=FALSE, ...) {
+  warning("No rgeos support in sp from October 2023;\nsee https://r-spatial.org/r/2023/05/15/evolution4.html")
   if (!requireNamespace("rgeos", quietly = TRUE))
     stop('package rgeos is needed to relate holes to their corresponding polygons')
   npols <- length(x@polygons)

--- a/R/over.R
+++ b/R/over.R
@@ -205,6 +205,7 @@ setMethod("over", signature("SpatialPoints", "SpatialPixelsDataFrame"),
 
 setMethod("over", signature("Spatial", "Spatial"),  # catch remaining:
 	function(x, y, returnList = FALSE, fn = NULL, ...) {
+        warning("No rgeos support in sp from October 2023;\nsee https://r-spatial.org/r/2023/05/15/evolution4.html")
 		.Deprecated("sf::st_intersects or sf::aggregate")
     	if (!requireNamespace("rgeos", quietly = TRUE))
 			stop("package rgeos is required for additional over methods")

--- a/R/projected.R
+++ b/R/projected.R
@@ -123,7 +123,8 @@ is.projectedCRS <- function(obj) {
                     else
                         !o
                 } else {
-                    warning("Package sf not available")
+                    if (get("startup_message", envir=.spOptions) != "none")
+                        warning("Package sf not available")
                     if (!is.null(wkt2)) # and old rgdal version
 		        substring(wkt2, 1, 3) != "GEO"
 	            else if (is.na(p4str) || !nzchar(p4str))

--- a/R/projected.R
+++ b/R/projected.R
@@ -115,14 +115,16 @@ is.projectedCRS <- function(obj) {
 	if (is.null(wkt2) && is.na(p4str))
 		as.logical(NA)
 	else if (get("evolution_status", envir=.spOptions) == 2L) {
-		if (!requireNamespace("sf", quietly = TRUE))
-			stop("sf required for evolution_status==2L")
-		o <- try(sf::st_is_longlat(obj), silent=TRUE)
+		if (requireNamespace("sf", quietly = TRUE)) {
+		    o <- try(sf::st_is_longlat(obj), silent=TRUE)
 # rbgm workaround for +proj=utm +zone=18 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +# +a=6378137.0 +es=0.006694380022900787 +lon_0=-75d00 +lat_0=0d00 +x_0=500000.0 +y_0=0.0 +k=0.9996 in bgmfiles Final_CAM_Boxes_8.bgm
-                if (inherits(o, "try-error"))
-                    length(grep("longlat", p4str, fixed = TRUE)) == 0L
-                else
-                    !o
+                    if (inherits(o, "try-error"))
+                        length(grep("longlat", p4str, fixed = TRUE)) == 0L
+                    else
+                        !o
+                } else {
+                    warning("Package sf not available")
+                }
 	} else if (get("evolution_status", envir=.spOptions) == 0L && 
 			requireNamespace("rgdal", quietly = TRUE) &&
 			packageVersion("rgdal") >= "1.5.17" && rgdal::new_proj_and_gdal())

--- a/R/projected.R
+++ b/R/projected.R
@@ -124,6 +124,12 @@ is.projectedCRS <- function(obj) {
                         !o
                 } else {
                     warning("Package sf not available")
+                    if (!is.null(wkt2)) # and old rgdal version
+		        substring(wkt2, 1, 3) != "GEO"
+	            else if (is.na(p4str) || !nzchar(p4str))
+		        as.logical(NA)
+	            else
+		        length(grep("longlat", p4str, fixed = TRUE)) == 0L
                 }
 	} else if (get("evolution_status", envir=.spOptions) == 0L && 
 			requireNamespace("rgdal", quietly = TRUE) &&

--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@
 
 R Classes and Methods for Spatial Data.
 
-*Before* **sp** is loaded, `options("sp_evolution_status")` may be set to `0L` for legacy behaviour, `1L` for setting `CRS(, doCheckCRSArgs=FALSE, )` and other minor steps to block calls out to **rgdal** etc., and `2L` to use **sf** internally (not completed yet). If this option is not set, the environment variable `_SP_EVOLUTION_STATUS_` can be used, again *before* **sp** is loaded, set to `"0"`, `"1"` or `"2"`; this is used for running revdep checks under different evolution scenarios, anticipating [retirement of maptools, rgdal and rgeos](https://r-spatial.org/r/2022/04/12/evolution.html).
+From version 2.0.0, `sp` evolution status is changed to `2L` to use **sf** internally in place of `rgdal`, from default `0L` until now. See [this report](https://r-spatial.org/r/2023/05/15/evolution4.html) for adaptation details, and [this report](https://r-spatial.org/r/2023/04/10/evolution3.html) for progress on retiring `maptools`, `rgdal` and `rgeos`.
+
+*Before* **sp** is loaded, `options("sp_evolution_status")` may be set to `0L` for legacy behaviour, `1L` for setting `CRS(, doCheckCRSArgs=FALSE, )` and other minor steps to block calls out to **rgdal** etc., and `2L` to use **sf** internally. If this option is not set, the environment variable `_SP_EVOLUTION_STATUS_` can be used, again *before* **sp** is loaded, set to `"0"`, `"1"` or `"2"`; this is used for running revdep checks under different evolution scenarios, anticipating [retirement of maptools, rgdal and rgeos](https://r-spatial.org/r/2022/04/12/evolution.html).
+
+From `sp 1.6.0` published on CRAN 2023-01-19, these status settings may also be changed when `sp` is loaded, using `sp::get_evolution_status()` returning the current value, and `sp::set_evolution_status(value)`, where value can take the integer values `0L`, `1L` and `2L`. `sp 1.6.1` published on CRAN 2023-05-25 added start-up messages to alert users to imminent changes.
 
 See:
 

--- a/inst/include/sp.h
+++ b/inst/include/sp.h
@@ -8,7 +8,7 @@
 #endif
 /* remember to touch local_stubs.c */
 
-#define SP_VERSION "1.6-1"
+#define SP_VERSION "2.0-0"
 
 #include <R.h>
 /* RSB 091203 */

--- a/src/sp.h
+++ b/src/sp.h
@@ -8,7 +8,7 @@
 #endif
 /* remember to touch local_stubs.c */
 
-#define SP_VERSION "1.6-1"
+#define SP_VERSION "2.0-0"
 
 #include <R.h>
 /* RSB 091203 */

--- a/tests/agg.R
+++ b/tests/agg.R
@@ -1,35 +1,10 @@
 options("rgdal_show_exportToProj4_warnings"="none")
 library(sp)
-if (require(rgeos, quietly = TRUE)) {
 g = SpatialGrid(GridTopology(c(5,5), c(10,10), c(3,3)))
 p = as(g, "SpatialPolygons")
 p$z = c(1,0,1,0,1,0,1,0,1)
 cc = coordinates(g)
-#p$ag1 = aggregate(p, p, mean)[[1]]
-#p$ag1a = aggregate(p, p, mean, minDimension = 0)[[1]]
-#p$ag2 = aggregate(p, p, mean, minDimension = 1)[[1]]
-#p$ag3 = aggregate(p, p, mean, minDimension = 2)[[1]]
-#p$ag4 = aggregate(p, p, mean, areaWeighted=TRUE)[[1]]
 pts = cbind(c(9,21,21,9,9),c(9,9,21,21,9))
 sq = SpatialPolygons(list(Polygons(list(Polygon(pts)), "ID")))
 rnd2 = function(x) round(x, 2)
-#l = list(
-#	list("sp.text", cc, rnd2(p$z), which = 1),
-#	list("sp.text", cc, rnd2(p$ag1), which = 2),
-#	list("sp.text", cc, rnd2(p$ag1a), which = 3),
-#	list("sp.text", cc, rnd2(p$ag2), which = 4),
-#	list("sp.text", cc, rnd2(p$ag3), which = 5),
-#	list("sp.text", cc, rnd2(p$ag4), which = 6),
-#	list(sq, col = 'green', which = 6, first = FALSE, lwd = 2)
-#)
-#spplot(p, names.attr = c("source", "default aggregate", "minDimension=0", 
-#	"minDimension=1", "minDimension=2", "areaWeighted=TRUE"), layout = c(3,2), 
-#	as.table=TRUE, col.regions=bpy.colors(151)[50:151], cuts=100, 
-#	sp.layout = l, scales = list(draw = TRUE))
 
-#rnd2(c(aggregate(p, sq, mean)[[1]],
-#  aggregate(p, sq, mean, minDimension = 0)[[1]],
-#  aggregate(p, sq, mean, minDimension = 1)[[1]],
-#  aggregate(p, sq, mean, minDimension = 2)[[1]],
-#  aggregate(p, sq, mean, areaWeighted=TRUE)[[1]]))
-}

--- a/tests/agg.Rout.save
+++ b/tests/agg.Rout.save
@@ -20,7 +20,7 @@ Type 'q()' to quit R.
 The legacy packages maptools, rgdal, and rgeos, underpinning this package
 will retire shortly. Please refer to R-spatial evolution reports on
 https://r-spatial.org/r/2023/05/15/evolution4.html for details.
-This package is now running under evolution status 0 
+This package is now running under evolution status 2 
 > if (require(rgeos, quietly = TRUE)) {
 + g = SpatialGrid(GridTopology(c(5,5), c(10,10), c(3,3)))
 + p = as(g, "SpatialPolygons")
@@ -55,15 +55,15 @@ This package is now running under evolution status 0
 + #  aggregate(p, sq, mean, areaWeighted=TRUE)[[1]]))
 + }
 rgeos version: 0.6-3, (SVN revision 696)
- GEOS runtime version: 3.11.1-CAPI-1.17.1 
+ GEOS runtime version: 3.11.3dev-CAPI-1.17.3 
  Please note that rgeos will be retired during October 2023,
 plan transition to sf or terra functions using GEOS at your earliest convenience.
 See https://r-spatial.org/r/2023/05/15/evolution4.html for details.
  GEOS using OverlayNG
- Linking to sp version: 1.6-0 
+ Linking to sp version: 1.6-1 
  Polygon checking: TRUE 
 
 > 
 > proc.time()
    user  system elapsed 
-  0.652   0.055   0.701 
+  0.326   0.042   0.359 

--- a/tests/agg.Rout.save
+++ b/tests/agg.Rout.save
@@ -21,6 +21,8 @@ The legacy packages maptools, rgdal, and rgeos, underpinning the sp package,
 which was just loaded, will retire in October 2023.
 Please refer to R-spatial evolution reports for details, especially
 https://r-spatial.org/r/2023/05/15/evolution4.html.
+It may be desirable to make the sf package available;
+package maintainers should consider adding sf to Suggests:.
 The sp package is now running under evolution status 2
      (status 2 uses the sf package in place of rgdal)
 > g = SpatialGrid(GridTopology(c(5,5), c(10,10), c(3,3)))
@@ -34,4 +36,4 @@ The sp package is now running under evolution status 2
 > 
 > proc.time()
    user  system elapsed 
-  0.224   0.032   0.246 
+  0.244   0.030   0.266 

--- a/tests/agg.Rout.save
+++ b/tests/agg.Rout.save
@@ -17,10 +17,12 @@ Type 'q()' to quit R.
 
 > options("rgdal_show_exportToProj4_warnings"="none")
 > library(sp)
-The legacy packages maptools, rgdal, and rgeos, underpinning this package
-will retire shortly. Please refer to R-spatial evolution reports on
-https://r-spatial.org/r/2023/05/15/evolution4.html for details.
-This package is now running under evolution status 2 
+The legacy packages maptools, rgdal, and rgeos, underpinning the sp package,
+which was just loaded, will retire in October 2023.
+Please refer to R-spatial evolution reports for details, especially
+https://r-spatial.org/r/2023/05/15/evolution4.html.
+The sp package is now running under evolution status 2
+     (status 2 uses the sf package in place of rgdal)
 > if (require(rgeos, quietly = TRUE)) {
 + g = SpatialGrid(GridTopology(c(5,5), c(10,10), c(3,3)))
 + p = as(g, "SpatialPolygons")
@@ -60,10 +62,10 @@ rgeos version: 0.6-3, (SVN revision 696)
 plan transition to sf or terra functions using GEOS at your earliest convenience.
 See https://r-spatial.org/r/2023/05/15/evolution4.html for details.
  GEOS using OverlayNG
- Linking to sp version: 1.6-1 
+ Linking to sp version: 2.0-0 
  Polygon checking: TRUE 
 
 > 
 > proc.time()
    user  system elapsed 
-  0.326   0.042   0.359 
+  0.321   0.054   0.367 

--- a/tests/agg.Rout.save
+++ b/tests/agg.Rout.save
@@ -23,49 +23,15 @@ Please refer to R-spatial evolution reports for details, especially
 https://r-spatial.org/r/2023/05/15/evolution4.html.
 The sp package is now running under evolution status 2
      (status 2 uses the sf package in place of rgdal)
-> if (require(rgeos, quietly = TRUE)) {
-+ g = SpatialGrid(GridTopology(c(5,5), c(10,10), c(3,3)))
-+ p = as(g, "SpatialPolygons")
-+ p$z = c(1,0,1,0,1,0,1,0,1)
-+ cc = coordinates(g)
-+ #p$ag1 = aggregate(p, p, mean)[[1]]
-+ #p$ag1a = aggregate(p, p, mean, minDimension = 0)[[1]]
-+ #p$ag2 = aggregate(p, p, mean, minDimension = 1)[[1]]
-+ #p$ag3 = aggregate(p, p, mean, minDimension = 2)[[1]]
-+ #p$ag4 = aggregate(p, p, mean, areaWeighted=TRUE)[[1]]
-+ pts = cbind(c(9,21,21,9,9),c(9,9,21,21,9))
-+ sq = SpatialPolygons(list(Polygons(list(Polygon(pts)), "ID")))
-+ rnd2 = function(x) round(x, 2)
-+ #l = list(
-+ #	list("sp.text", cc, rnd2(p$z), which = 1),
-+ #	list("sp.text", cc, rnd2(p$ag1), which = 2),
-+ #	list("sp.text", cc, rnd2(p$ag1a), which = 3),
-+ #	list("sp.text", cc, rnd2(p$ag2), which = 4),
-+ #	list("sp.text", cc, rnd2(p$ag3), which = 5),
-+ #	list("sp.text", cc, rnd2(p$ag4), which = 6),
-+ #	list(sq, col = 'green', which = 6, first = FALSE, lwd = 2)
-+ #)
-+ #spplot(p, names.attr = c("source", "default aggregate", "minDimension=0", 
-+ #	"minDimension=1", "minDimension=2", "areaWeighted=TRUE"), layout = c(3,2), 
-+ #	as.table=TRUE, col.regions=bpy.colors(151)[50:151], cuts=100, 
-+ #	sp.layout = l, scales = list(draw = TRUE))
-+ 
-+ #rnd2(c(aggregate(p, sq, mean)[[1]],
-+ #  aggregate(p, sq, mean, minDimension = 0)[[1]],
-+ #  aggregate(p, sq, mean, minDimension = 1)[[1]],
-+ #  aggregate(p, sq, mean, minDimension = 2)[[1]],
-+ #  aggregate(p, sq, mean, areaWeighted=TRUE)[[1]]))
-+ }
-rgeos version: 0.6-3, (SVN revision 696)
- GEOS runtime version: 3.11.3dev-CAPI-1.17.3 
- Please note that rgeos will be retired during October 2023,
-plan transition to sf or terra functions using GEOS at your earliest convenience.
-See https://r-spatial.org/r/2023/05/15/evolution4.html for details.
- GEOS using OverlayNG
- Linking to sp version: 2.0-0 
- Polygon checking: TRUE 
-
+> g = SpatialGrid(GridTopology(c(5,5), c(10,10), c(3,3)))
+> p = as(g, "SpatialPolygons")
+> p$z = c(1,0,1,0,1,0,1,0,1)
+> cc = coordinates(g)
+> pts = cbind(c(9,21,21,9,9),c(9,9,21,21,9))
+> sq = SpatialPolygons(list(Polygons(list(Polygon(pts)), "ID")))
+> rnd2 = function(x) round(x, 2)
+> 
 > 
 > proc.time()
    user  system elapsed 
-  0.321   0.054   0.367 
+  0.224   0.032   0.246 

--- a/tests/base.Rout.save
+++ b/tests/base.Rout.save
@@ -21,6 +21,8 @@ The legacy packages maptools, rgdal, and rgeos, underpinning the sp package,
 which was just loaded, will retire in October 2023.
 Please refer to R-spatial evolution reports for details, especially
 https://r-spatial.org/r/2023/05/15/evolution4.html.
+It may be desirable to make the sf package available;
+package maintainers should consider adding sf to Suggests:.
 The sp package is now running under evolution status 2
      (status 2 uses the sf package in place of rgdal)
 > data(meuse)
@@ -466,4 +468,4 @@ Data attributes:
 > 
 > proc.time()
    user  system elapsed 
-  0.391   0.057   0.439 
+  0.466   0.034   0.495 

--- a/tests/base.Rout.save
+++ b/tests/base.Rout.save
@@ -17,10 +17,12 @@ Type 'q()' to quit R.
 
 > options("rgdal_show_exportToProj4_warnings"="none")
 > library(sp)
-The legacy packages maptools, rgdal, and rgeos, underpinning this package
-will retire shortly. Please refer to R-spatial evolution reports on
-https://r-spatial.org/r/2023/05/15/evolution4.html for details.
-This package is now running under evolution status 2 
+The legacy packages maptools, rgdal, and rgeos, underpinning the sp package,
+which was just loaded, will retire in October 2023.
+Please refer to R-spatial evolution reports for details, especially
+https://r-spatial.org/r/2023/05/15/evolution4.html.
+The sp package is now running under evolution status 2
+     (status 2 uses the sf package in place of rgdal)
 > data(meuse)
 > x = meuse[1:10, ] # limit the output
 > coordinates(x) = c("x", "y") # names
@@ -464,4 +466,4 @@ Data attributes:
 > 
 > proc.time()
    user  system elapsed 
-  0.389   0.062   0.442 
+  0.391   0.057   0.439 

--- a/tests/base.Rout.save
+++ b/tests/base.Rout.save
@@ -20,7 +20,7 @@ Type 'q()' to quit R.
 The legacy packages maptools, rgdal, and rgeos, underpinning this package
 will retire shortly. Please refer to R-spatial evolution reports on
 https://r-spatial.org/r/2023/05/15/evolution4.html for details.
-This package is now running under evolution status 0 
+This package is now running under evolution status 2 
 > data(meuse)
 > x = meuse[1:10, ] # limit the output
 > coordinates(x) = c("x", "y") # names
@@ -464,4 +464,4 @@ Data attributes:
 > 
 > proc.time()
    user  system elapsed 
-  0.386   0.062   0.439 
+  0.389   0.062   0.442 

--- a/tests/fail1.Rout.save
+++ b/tests/fail1.Rout.save
@@ -20,7 +20,7 @@ Type 'q()' to quit R.
 The legacy packages maptools, rgdal, and rgeos, underpinning this package
 will retire shortly. Please refer to R-spatial evolution reports on
 https://r-spatial.org/r/2023/05/15/evolution4.html for details.
-This package is now running under evolution status 0 
+This package is now running under evolution status 2 
 > data(meuse)
 > x = meuse
 > 
@@ -214,8 +214,26 @@ x          5.721109 0.0005312853        84
 y         50.955770 0.0003318105       112
 > 
 > try(CRS("+proj=latlon +ellps=WGS84"))
-Error in CRS("+proj=latlon +ellps=WGS84") : 
-  northings must follow eastings: +proj=latlon +ellps=WGS84
+Coordinate Reference System:
+Deprecated Proj.4 representation: +proj=longlat +ellps=WGS84 +no_defs 
+WKT2 2019 representation:
+GEOGCRS["unknown",
+    DATUM["Unknown based on WGS84 ellipsoid",
+        ELLIPSOID["WGS 84",6378137,298.257223563,
+            LENGTHUNIT["metre",1],
+            ID["EPSG",7030]]],
+    PRIMEM["Greenwich",0,
+        ANGLEUNIT["degree",0.0174532925199433],
+        ID["EPSG",8901]],
+    CS[ellipsoidal,2],
+        AXIS["longitude",east,
+            ORDER[1],
+            ANGLEUNIT["degree",0.0174532925199433,
+                ID["EPSG",9122]]],
+        AXIS["latitude",north,
+            ORDER[2],
+            ANGLEUNIT["degree",0.0174532925199433,
+                ID["EPSG",9122]]]] 
 > try(CRS("+proj=lonlat +ellps=WGS84"))
 Coordinate Reference System:
 Deprecated Proj.4 representation: +proj=longlat +ellps=WGS84 +no_defs 
@@ -237,10 +255,7 @@ GEOGCRS["unknown",
             ORDER[2],
             ANGLEUNIT["degree",0.0174532925199433,
                 ID["EPSG",9122]]]] 
-Warning message:
-In CRS("+proj=lonlat +ellps=WGS84") :
-  'lonlat' changed to 'longlat': +proj=longlat +ellps=WGS84
 > 
 > proc.time()
    user  system elapsed 
-  0.547   0.073   0.612 
+  0.695   0.071   0.757 

--- a/tests/fail1.Rout.save
+++ b/tests/fail1.Rout.save
@@ -17,10 +17,12 @@ Type 'q()' to quit R.
 
 > options("rgdal_show_exportToProj4_warnings"="none")
 > library(sp)
-The legacy packages maptools, rgdal, and rgeos, underpinning this package
-will retire shortly. Please refer to R-spatial evolution reports on
-https://r-spatial.org/r/2023/05/15/evolution4.html for details.
-This package is now running under evolution status 2 
+The legacy packages maptools, rgdal, and rgeos, underpinning the sp package,
+which was just loaded, will retire in October 2023.
+Please refer to R-spatial evolution reports for details, especially
+https://r-spatial.org/r/2023/05/15/evolution4.html.
+The sp package is now running under evolution status 2
+     (status 2 uses the sf package in place of rgdal)
 > data(meuse)
 > x = meuse
 > 
@@ -218,7 +220,7 @@ Coordinate Reference System:
 Deprecated Proj.4 representation: +proj=longlat +ellps=WGS84 +no_defs 
 WKT2 2019 representation:
 GEOGCRS["unknown",
-    DATUM["Unknown based on WGS84 ellipsoid",
+    DATUM["Unknown based on WGS 84 ellipsoid",
         ELLIPSOID["WGS 84",6378137,298.257223563,
             LENGTHUNIT["metre",1],
             ID["EPSG",7030]]],
@@ -239,7 +241,7 @@ Coordinate Reference System:
 Deprecated Proj.4 representation: +proj=longlat +ellps=WGS84 +no_defs 
 WKT2 2019 representation:
 GEOGCRS["unknown",
-    DATUM["Unknown based on WGS84 ellipsoid",
+    DATUM["Unknown based on WGS 84 ellipsoid",
         ELLIPSOID["WGS 84",6378137,298.257223563,
             LENGTHUNIT["metre",1],
             ID["EPSG",7030]]],
@@ -258,4 +260,4 @@ GEOGCRS["unknown",
 > 
 > proc.time()
    user  system elapsed 
-  0.695   0.071   0.757 
+  0.721   0.065   0.778 

--- a/tests/fail1.Rout.save
+++ b/tests/fail1.Rout.save
@@ -21,6 +21,8 @@ The legacy packages maptools, rgdal, and rgeos, underpinning the sp package,
 which was just loaded, will retire in October 2023.
 Please refer to R-spatial evolution reports for details, especially
 https://r-spatial.org/r/2023/05/15/evolution4.html.
+It may be desirable to make the sf package available;
+package maintainers should consider adding sf to Suggests:.
 The sp package is now running under evolution status 2
      (status 2 uses the sf package in place of rgdal)
 > data(meuse)
@@ -260,4 +262,4 @@ GEOGCRS["unknown",
 > 
 > proc.time()
    user  system elapsed 
-  0.721   0.065   0.778 
+  0.830   0.046   0.881 

--- a/tests/grid.Rout.save
+++ b/tests/grid.Rout.save
@@ -21,6 +21,8 @@ The legacy packages maptools, rgdal, and rgeos, underpinning the sp package,
 which was just loaded, will retire in October 2023.
 Please refer to R-spatial evolution reports for details, especially
 https://r-spatial.org/r/2023/05/15/evolution4.html.
+It may be desirable to make the sf package available;
+package maintainers should consider adding sf to Suggests:.
 The sp package is now running under evolution status 2
      (status 2 uses the sf package in place of rgdal)
 > data(meuse.grid)
@@ -282,4 +284,4 @@ Coordinate Reference System (CRS) arguments: NA
 > 
 > proc.time()
    user  system elapsed 
-  0.427   0.060   0.478 
+  0.514   0.034   0.542 

--- a/tests/grid.Rout.save
+++ b/tests/grid.Rout.save
@@ -17,10 +17,12 @@ Type 'q()' to quit R.
 
 > options("rgdal_show_exportToProj4_warnings"="none")
 > library(sp)
-The legacy packages maptools, rgdal, and rgeos, underpinning this package
-will retire shortly. Please refer to R-spatial evolution reports on
-https://r-spatial.org/r/2023/05/15/evolution4.html for details.
-This package is now running under evolution status 2 
+The legacy packages maptools, rgdal, and rgeos, underpinning the sp package,
+which was just loaded, will retire in October 2023.
+Please refer to R-spatial evolution reports for details, especially
+https://r-spatial.org/r/2023/05/15/evolution4.html.
+The sp package is now running under evolution status 2
+     (status 2 uses the sf package in place of rgdal)
 > data(meuse.grid)
 > x = meuse.grid
 > coordinates(x) = c("x", "y")
@@ -280,4 +282,4 @@ Coordinate Reference System (CRS) arguments: NA
 > 
 > proc.time()
    user  system elapsed 
-  0.437   0.052   0.480 
+  0.427   0.060   0.478 

--- a/tests/grid.Rout.save
+++ b/tests/grid.Rout.save
@@ -20,7 +20,7 @@ Type 'q()' to quit R.
 The legacy packages maptools, rgdal, and rgeos, underpinning this package
 will retire shortly. Please refer to R-spatial evolution reports on
 https://r-spatial.org/r/2023/05/15/evolution4.html for details.
-This package is now running under evolution status 0 
+This package is now running under evolution status 2 
 > data(meuse.grid)
 > x = meuse.grid
 > coordinates(x) = c("x", "y")
@@ -280,4 +280,4 @@ Coordinate Reference System (CRS) arguments: NA
 > 
 > proc.time()
    user  system elapsed 
-  0.432   0.067   0.490 
+  0.437   0.052   0.480 

--- a/tests/over2.R
+++ b/tests/over2.R
@@ -1,43 +1,8 @@
 options("rgdal_show_exportToProj4_warnings"="none")
 library(sp)
 
-if (require(rgeos, quietly = TRUE)) {
 g = SpatialGrid(GridTopology(c(0,0), c(1,1), c(3,3)))
 p = as(g, "SpatialPolygons")
 over(g,g)
-over(p,p)
-over(p,p, minDimension = 0) # orders; different names
-over(p,g)
-over(g,p)
 
-over(p,p,returnList=TRUE)
-over(p,p,returnList=TRUE, minDimension=0)
-over(p,p,returnList=TRUE, minDimension=1)
-over(p,p,returnList=TRUE, minDimension=2)
-over(p,p[1:6],minDimension=2)
 
-x2 = x1 = cbind(c(0,1,1,0,0), c(0,0,1,1,0))
-x1[,1] = x1[,1]+0.5
-x1[,2] = x1[,2]+0.25
-sp = SpatialPolygons(list(
- Polygons(list(Polygon(x1)), "x1"),
- Polygons(list(Polygon(x2)), "x2")))
-pt = SpatialPoints(cbind(0.5,0.5)) # on border of x1
-row.names(pt) = "pt1"
-over(pt,sp)
-over(pt,sp,returnList=TRUE)
-
-rgeos::overGeomGeom(pt,sp)
-rgeos::overGeomGeom(pt,sp,returnList=TRUE)
-
-plot(sp)
-plot(pt,add=TRUE,col='red',pch=16)
-#    x1     x2 
-#	"F0FF" "0FFF" 
-# it would be nice to have these sorted "2, 1" instead of "1, 2" - use
-rgeos::overGeomGeom(pt,sp,returnList=TRUE, minDimension = 0)
-
-rgeos::overGeomGeom(pt,pt,minDimension=2)
-rgeos::overGeomGeom(pt,pt,minDimension=1)
-rgeos::overGeomGeom(pt,pt,minDimension=0)
-}

--- a/tests/over2.Rout.save
+++ b/tests/over2.Rout.save
@@ -20,7 +20,7 @@ Type 'q()' to quit R.
 The legacy packages maptools, rgdal, and rgeos, underpinning this package
 will retire shortly. Please refer to R-spatial evolution reports on
 https://r-spatial.org/r/2023/05/15/evolution4.html for details.
-This package is now running under evolution status 0 
+This package is now running under evolution status 2 
 > 
 > if (require(rgeos, quietly = TRUE)) {
 + g = SpatialGrid(GridTopology(c(0,0), c(1,1), c(3,3)))
@@ -63,12 +63,12 @@ This package is now running under evolution status 0
 + rgeos::overGeomGeom(pt,pt,minDimension=0)
 + }
 rgeos version: 0.6-3, (SVN revision 696)
- GEOS runtime version: 3.11.1-CAPI-1.17.1 
+ GEOS runtime version: 3.11.3dev-CAPI-1.17.3 
  Please note that rgeos will be retired during October 2023,
 plan transition to sf or terra functions using GEOS at your earliest convenience.
 See https://r-spatial.org/r/2023/05/15/evolution4.html for details.
  GEOS using OverlayNG
- Linking to sp version: 1.6-0 
+ Linking to sp version: 1.6-1 
  Polygon checking: TRUE 
 
 pt1 
@@ -76,4 +76,4 @@ pt1
 > 
 > proc.time()
    user  system elapsed 
-  0.705   0.047   0.745 
+  0.395   0.058   0.445 

--- a/tests/over2.Rout.save
+++ b/tests/over2.Rout.save
@@ -24,58 +24,14 @@ https://r-spatial.org/r/2023/05/15/evolution4.html.
 The sp package is now running under evolution status 2
      (status 2 uses the sf package in place of rgdal)
 > 
-> if (require(rgeos, quietly = TRUE)) {
-+ g = SpatialGrid(GridTopology(c(0,0), c(1,1), c(3,3)))
-+ p = as(g, "SpatialPolygons")
-+ over(g,g)
-+ over(p,p)
-+ over(p,p, minDimension = 0) # orders; different names
-+ over(p,g)
-+ over(g,p)
-+ 
-+ over(p,p,returnList=TRUE)
-+ over(p,p,returnList=TRUE, minDimension=0)
-+ over(p,p,returnList=TRUE, minDimension=1)
-+ over(p,p,returnList=TRUE, minDimension=2)
-+ over(p,p[1:6],minDimension=2)
-+ 
-+ x2 = x1 = cbind(c(0,1,1,0,0), c(0,0,1,1,0))
-+ x1[,1] = x1[,1]+0.5
-+ x1[,2] = x1[,2]+0.25
-+ sp = SpatialPolygons(list(
-+  Polygons(list(Polygon(x1)), "x1"),
-+  Polygons(list(Polygon(x2)), "x2")))
-+ pt = SpatialPoints(cbind(0.5,0.5)) # on border of x1
-+ row.names(pt) = "pt1"
-+ over(pt,sp)
-+ over(pt,sp,returnList=TRUE)
-+ 
-+ rgeos::overGeomGeom(pt,sp)
-+ rgeos::overGeomGeom(pt,sp,returnList=TRUE)
-+ 
-+ plot(sp)
-+ plot(pt,add=TRUE,col='red',pch=16)
-+ #    x1     x2 
-+ #	"F0FF" "0FFF" 
-+ # it would be nice to have these sorted "2, 1" instead of "1, 2" - use
-+ rgeos::overGeomGeom(pt,sp,returnList=TRUE, minDimension = 0)
-+ 
-+ rgeos::overGeomGeom(pt,pt,minDimension=2)
-+ rgeos::overGeomGeom(pt,pt,minDimension=1)
-+ rgeos::overGeomGeom(pt,pt,minDimension=0)
-+ }
-rgeos version: 0.6-3, (SVN revision 696)
- GEOS runtime version: 3.11.3dev-CAPI-1.17.3 
- Please note that rgeos will be retired during October 2023,
-plan transition to sf or terra functions using GEOS at your earliest convenience.
-See https://r-spatial.org/r/2023/05/15/evolution4.html for details.
- GEOS using OverlayNG
- Linking to sp version: 2.0-0 
- Polygon checking: TRUE 
-
-pt1 
-  1 
+> g = SpatialGrid(GridTopology(c(0,0), c(1,1), c(3,3)))
+> p = as(g, "SpatialPolygons")
+> over(g,g)
+1 2 3 4 5 6 7 8 9 
+1 2 3 4 5 6 7 8 9 
+> 
+> 
 > 
 > proc.time()
    user  system elapsed 
-  0.379   0.051   0.421 
+  0.206   0.037   0.234 

--- a/tests/over2.Rout.save
+++ b/tests/over2.Rout.save
@@ -17,10 +17,12 @@ Type 'q()' to quit R.
 
 > options("rgdal_show_exportToProj4_warnings"="none")
 > library(sp)
-The legacy packages maptools, rgdal, and rgeos, underpinning this package
-will retire shortly. Please refer to R-spatial evolution reports on
-https://r-spatial.org/r/2023/05/15/evolution4.html for details.
-This package is now running under evolution status 2 
+The legacy packages maptools, rgdal, and rgeos, underpinning the sp package,
+which was just loaded, will retire in October 2023.
+Please refer to R-spatial evolution reports for details, especially
+https://r-spatial.org/r/2023/05/15/evolution4.html.
+The sp package is now running under evolution status 2
+     (status 2 uses the sf package in place of rgdal)
 > 
 > if (require(rgeos, quietly = TRUE)) {
 + g = SpatialGrid(GridTopology(c(0,0), c(1,1), c(3,3)))
@@ -68,7 +70,7 @@ rgeos version: 0.6-3, (SVN revision 696)
 plan transition to sf or terra functions using GEOS at your earliest convenience.
 See https://r-spatial.org/r/2023/05/15/evolution4.html for details.
  GEOS using OverlayNG
- Linking to sp version: 1.6-1 
+ Linking to sp version: 2.0-0 
  Polygon checking: TRUE 
 
 pt1 
@@ -76,4 +78,4 @@ pt1
 > 
 > proc.time()
    user  system elapsed 
-  0.395   0.058   0.445 
+  0.379   0.051   0.421 

--- a/tests/over2.Rout.save
+++ b/tests/over2.Rout.save
@@ -21,6 +21,8 @@ The legacy packages maptools, rgdal, and rgeos, underpinning the sp package,
 which was just loaded, will retire in October 2023.
 Please refer to R-spatial evolution reports for details, especially
 https://r-spatial.org/r/2023/05/15/evolution4.html.
+It may be desirable to make the sf package available;
+package maintainers should consider adding sf to Suggests:.
 The sp package is now running under evolution status 2
      (status 2 uses the sf package in place of rgdal)
 > 
@@ -34,4 +36,4 @@ The sp package is now running under evolution status 2
 > 
 > proc.time()
    user  system elapsed 
-  0.206   0.037   0.234 
+  0.212   0.041   0.246 

--- a/tests/pass1.Rout.save
+++ b/tests/pass1.Rout.save
@@ -17,10 +17,12 @@ Type 'q()' to quit R.
 
 > options("rgdal_show_exportToProj4_warnings"="none")
 > library(sp)
-The legacy packages maptools, rgdal, and rgeos, underpinning this package
-will retire shortly. Please refer to R-spatial evolution reports on
-https://r-spatial.org/r/2023/05/15/evolution4.html for details.
-This package is now running under evolution status 2 
+The legacy packages maptools, rgdal, and rgeos, underpinning the sp package,
+which was just loaded, will retire in October 2023.
+Please refer to R-spatial evolution reports for details, especially
+https://r-spatial.org/r/2023/05/15/evolution4.html.
+The sp package is now running under evolution status 2
+     (status 2 uses the sf package in place of rgdal)
 > data(meuse)
 > x = meuse
 > coordinates(x) = cbind(rnorm(155), rnorm(155))
@@ -605,4 +607,4 @@ Error in SpatialPointsDataFrame(pts, df, match.ID = TRUE) :
 > 
 > proc.time()
    user  system elapsed 
-  0.810   0.086   0.889 
+  0.816   0.081   0.890 

--- a/tests/pass1.Rout.save
+++ b/tests/pass1.Rout.save
@@ -20,7 +20,7 @@ Type 'q()' to quit R.
 The legacy packages maptools, rgdal, and rgeos, underpinning this package
 will retire shortly. Please refer to R-spatial evolution reports on
 https://r-spatial.org/r/2023/05/15/evolution4.html for details.
-This package is now running under evolution status 0 
+This package is now running under evolution status 2 
 > data(meuse)
 > x = meuse
 > coordinates(x) = cbind(rnorm(155), rnorm(155))
@@ -289,6 +289,9 @@ Data attributes:
 > 
 > # test behaviour on zero-length objects:
 > demo(meuse, ask = FALSE, echo = FALSE)
+Warning message:
+In CPL_crs_from_input(x) :
+  GDAL Message 1: +init=epsg:XXXX syntax is deprecated. It might return a CRS with a non-EPSG compliant axis order.
 > p = as(meuse, "SpatialPoints")
 > 
 > p[0]
@@ -602,4 +605,4 @@ Error in SpatialPointsDataFrame(pts, df, match.ID = TRUE) :
 > 
 > proc.time()
    user  system elapsed 
-  0.595   0.087   0.673 
+  0.810   0.086   0.889 

--- a/tests/pass1.Rout.save
+++ b/tests/pass1.Rout.save
@@ -21,6 +21,8 @@ The legacy packages maptools, rgdal, and rgeos, underpinning the sp package,
 which was just loaded, will retire in October 2023.
 Please refer to R-spatial evolution reports for details, especially
 https://r-spatial.org/r/2023/05/15/evolution4.html.
+It may be desirable to make the sf package available;
+package maintainers should consider adding sf to Suggests:.
 The sp package is now running under evolution status 2
      (status 2 uses the sf package in place of rgdal)
 > data(meuse)
@@ -607,4 +609,4 @@ Error in SpatialPointsDataFrame(pts, df, match.ID = TRUE) :
 > 
 > proc.time()
    user  system elapsed 
-  0.816   0.081   0.890 
+  0.959   0.060   1.023 

--- a/tests/point.in.polygon.Rout.save
+++ b/tests/point.in.polygon.Rout.save
@@ -20,7 +20,7 @@ Type 'q()' to quit R.
 The legacy packages maptools, rgdal, and rgeos, underpinning this package
 will retire shortly. Please refer to R-spatial evolution reports on
 https://r-spatial.org/r/2023/05/15/evolution4.html for details.
-This package is now running under evolution status 0 
+This package is now running under evolution status 2 
 > 
 > # open polygon:
 > print(point.in.polygon(1:10,1:10,c(3,5,5,3),c(3,3,5,5)))
@@ -31,4 +31,4 @@ This package is now running under evolution status 0
 > 
 > proc.time()
    user  system elapsed 
-  0.191   0.042   0.223 
+  0.195   0.041   0.226 

--- a/tests/point.in.polygon.Rout.save
+++ b/tests/point.in.polygon.Rout.save
@@ -21,6 +21,8 @@ The legacy packages maptools, rgdal, and rgeos, underpinning the sp package,
 which was just loaded, will retire in October 2023.
 Please refer to R-spatial evolution reports for details, especially
 https://r-spatial.org/r/2023/05/15/evolution4.html.
+It may be desirable to make the sf package available;
+package maintainers should consider adding sf to Suggests:.
 The sp package is now running under evolution status 2
      (status 2 uses the sf package in place of rgdal)
 > 
@@ -33,4 +35,4 @@ The sp package is now running under evolution status 2
 > 
 > proc.time()
    user  system elapsed 
-  0.196   0.037   0.223 
+  0.223   0.026   0.242 

--- a/tests/point.in.polygon.Rout.save
+++ b/tests/point.in.polygon.Rout.save
@@ -17,10 +17,12 @@ Type 'q()' to quit R.
 
 > options("rgdal_show_exportToProj4_warnings"="none")
 > library(sp)
-The legacy packages maptools, rgdal, and rgeos, underpinning this package
-will retire shortly. Please refer to R-spatial evolution reports on
-https://r-spatial.org/r/2023/05/15/evolution4.html for details.
-This package is now running under evolution status 2 
+The legacy packages maptools, rgdal, and rgeos, underpinning the sp package,
+which was just loaded, will retire in October 2023.
+Please refer to R-spatial evolution reports for details, especially
+https://r-spatial.org/r/2023/05/15/evolution4.html.
+The sp package is now running under evolution status 2
+     (status 2 uses the sf package in place of rgdal)
 > 
 > # open polygon:
 > print(point.in.polygon(1:10,1:10,c(3,5,5,3),c(3,3,5,5)))
@@ -31,4 +33,4 @@ This package is now running under evolution status 2
 > 
 > proc.time()
    user  system elapsed 
-  0.195   0.041   0.226 
+  0.196   0.037   0.223 

--- a/tests/sel.Rout.save
+++ b/tests/sel.Rout.save
@@ -20,7 +20,7 @@ Type 'q()' to quit R.
 The legacy packages maptools, rgdal, and rgeos, underpinning this package
 will retire shortly. Please refer to R-spatial evolution reports on
 https://r-spatial.org/r/2023/05/15/evolution4.html for details.
-This package is now running under evolution status 0 
+This package is now running under evolution status 2 
 > x = c(0.5, 1.5, 0.5, 1.5, 1.6)
 > y = c(1.5, 1.5, 0.5, 0.5, 0.5)
 > xy = cbind(x,y)
@@ -205,4 +205,4 @@ e 2 c
 > 
 > proc.time()
    user  system elapsed 
-  0.399   0.046   0.436 
+  0.381   0.060   0.432 

--- a/tests/sel.Rout.save
+++ b/tests/sel.Rout.save
@@ -17,10 +17,12 @@ Type 'q()' to quit R.
 
 > options("rgdal_show_exportToProj4_warnings"="none")
 > library(sp)
-The legacy packages maptools, rgdal, and rgeos, underpinning this package
-will retire shortly. Please refer to R-spatial evolution reports on
-https://r-spatial.org/r/2023/05/15/evolution4.html for details.
-This package is now running under evolution status 2 
+The legacy packages maptools, rgdal, and rgeos, underpinning the sp package,
+which was just loaded, will retire in October 2023.
+Please refer to R-spatial evolution reports for details, especially
+https://r-spatial.org/r/2023/05/15/evolution4.html.
+The sp package is now running under evolution status 2
+     (status 2 uses the sf package in place of rgdal)
 > x = c(0.5, 1.5, 0.5, 1.5, 1.6)
 > y = c(1.5, 1.5, 0.5, 0.5, 0.5)
 > xy = cbind(x,y)
@@ -205,4 +207,4 @@ e 2 c
 > 
 > proc.time()
    user  system elapsed 
-  0.381   0.060   0.432 
+  0.389   0.054   0.434 

--- a/tests/sel.Rout.save
+++ b/tests/sel.Rout.save
@@ -21,6 +21,8 @@ The legacy packages maptools, rgdal, and rgeos, underpinning the sp package,
 which was just loaded, will retire in October 2023.
 Please refer to R-spatial evolution reports for details, especially
 https://r-spatial.org/r/2023/05/15/evolution4.html.
+It may be desirable to make the sf package available;
+package maintainers should consider adding sf to Suggests:.
 The sp package is now running under evolution status 2
      (status 2 uses the sf package in place of rgdal)
 > x = c(0.5, 1.5, 0.5, 1.5, 1.6)
@@ -207,4 +209,4 @@ e 2 c
 > 
 > proc.time()
    user  system elapsed 
-  0.389   0.054   0.434 
+  0.474   0.034   0.501 

--- a/tests/sp1.Rout.save
+++ b/tests/sp1.Rout.save
@@ -20,7 +20,7 @@ Type 'q()' to quit R.
 The legacy packages maptools, rgdal, and rgeos, underpinning this package
 will retire shortly. Please refer to R-spatial evolution reports on
 https://r-spatial.org/r/2023/05/15/evolution4.html for details.
-This package is now running under evolution status 0 
+This package is now running under evolution status 2 
 > data(meuse)
 > x = meuse
 > nm <- names(meuse)
@@ -335,4 +335,4 @@ Data attributes:
 > 
 > proc.time()
    user  system elapsed 
-  0.300   0.038   0.329 
+  0.296   0.041   0.328 

--- a/tests/sp1.Rout.save
+++ b/tests/sp1.Rout.save
@@ -17,10 +17,12 @@ Type 'q()' to quit R.
 
 > options("rgdal_show_exportToProj4_warnings"="none")
 > library(sp)
-The legacy packages maptools, rgdal, and rgeos, underpinning this package
-will retire shortly. Please refer to R-spatial evolution reports on
-https://r-spatial.org/r/2023/05/15/evolution4.html for details.
-This package is now running under evolution status 2 
+The legacy packages maptools, rgdal, and rgeos, underpinning the sp package,
+which was just loaded, will retire in October 2023.
+Please refer to R-spatial evolution reports for details, especially
+https://r-spatial.org/r/2023/05/15/evolution4.html.
+The sp package is now running under evolution status 2
+     (status 2 uses the sf package in place of rgdal)
 > data(meuse)
 > x = meuse
 > nm <- names(meuse)
@@ -335,4 +337,4 @@ Data attributes:
 > 
 > proc.time()
    user  system elapsed 
-  0.296   0.041   0.328 
+  0.284   0.054   0.329 

--- a/tests/sp1.Rout.save
+++ b/tests/sp1.Rout.save
@@ -21,6 +21,8 @@ The legacy packages maptools, rgdal, and rgeos, underpinning the sp package,
 which was just loaded, will retire in October 2023.
 Please refer to R-spatial evolution reports for details, especially
 https://r-spatial.org/r/2023/05/15/evolution4.html.
+It may be desirable to make the sf package available;
+package maintainers should consider adding sf to Suggests:.
 The sp package is now running under evolution status 2
      (status 2 uses the sf package in place of rgdal)
 > data(meuse)
@@ -337,4 +339,4 @@ Data attributes:
 > 
 > proc.time()
    user  system elapsed 
-  0.284   0.054   0.329 
+  0.352   0.035   0.381 

--- a/tests/spDists.Rout.save
+++ b/tests/spDists.Rout.save
@@ -20,7 +20,7 @@ Type 'q()' to quit R.
 The legacy packages maptools, rgdal, and rgeos, underpinning this package
 will retire shortly. Please refer to R-spatial evolution reports on
 https://r-spatial.org/r/2023/05/15/evolution4.html for details.
-This package is now running under evolution status 0 
+This package is now running under evolution status 2 
 > data(meuse)
 > data(meuse.grid)
 > coordinates(meuse) = ~x+y
@@ -46,4 +46,4 @@ This package is now running under evolution status 0
 > 
 > proc.time()
    user  system elapsed 
-  0.705   0.254   0.951 
+  0.716   0.224   0.933 

--- a/tests/spDists.Rout.save
+++ b/tests/spDists.Rout.save
@@ -21,6 +21,8 @@ The legacy packages maptools, rgdal, and rgeos, underpinning the sp package,
 which was just loaded, will retire in October 2023.
 Please refer to R-spatial evolution reports for details, especially
 https://r-spatial.org/r/2023/05/15/evolution4.html.
+It may be desirable to make the sf package available;
+package maintainers should consider adding sf to Suggests:.
 The sp package is now running under evolution status 2
      (status 2 uses the sf package in place of rgdal)
 > data(meuse)
@@ -48,4 +50,4 @@ The sp package is now running under evolution status 2
 > 
 > proc.time()
    user  system elapsed 
-  0.719   0.221   0.931 
+  0.826   0.202   1.022 

--- a/tests/spDists.Rout.save
+++ b/tests/spDists.Rout.save
@@ -17,10 +17,12 @@ Type 'q()' to quit R.
 
 > options("rgdal_show_exportToProj4_warnings"="none")
 > library(sp)
-The legacy packages maptools, rgdal, and rgeos, underpinning this package
-will retire shortly. Please refer to R-spatial evolution reports on
-https://r-spatial.org/r/2023/05/15/evolution4.html for details.
-This package is now running under evolution status 2 
+The legacy packages maptools, rgdal, and rgeos, underpinning the sp package,
+which was just loaded, will retire in October 2023.
+Please refer to R-spatial evolution reports for details, especially
+https://r-spatial.org/r/2023/05/15/evolution4.html.
+The sp package is now running under evolution status 2
+     (status 2 uses the sf package in place of rgdal)
 > data(meuse)
 > data(meuse.grid)
 > coordinates(meuse) = ~x+y
@@ -46,4 +48,4 @@ This package is now running under evolution status 2
 > 
 > proc.time()
    user  system elapsed 
-  0.716   0.224   0.933 
+  0.719   0.221   0.931 

--- a/tests/spplot.Rout.save
+++ b/tests/spplot.Rout.save
@@ -20,7 +20,7 @@ Type 'q()' to quit R.
 The legacy packages maptools, rgdal, and rgeos, underpinning this package
 will retire shortly. Please refer to R-spatial evolution reports on
 https://r-spatial.org/r/2023/05/15/evolution4.html for details.
-This package is now running under evolution status 0 
+This package is now running under evolution status 2 
 > xy = expand.grid(x = 1:4, y = 1:4)
 > xy.sp = SpatialPoints(xy)
 > gridded(xy.sp) = T
@@ -50,4 +50,4 @@ Coordinate Reference System (CRS) arguments: NA
 > 
 > proc.time()
    user  system elapsed 
-  0.389   0.050   0.430 
+  0.376   0.059   0.425 

--- a/tests/spplot.Rout.save
+++ b/tests/spplot.Rout.save
@@ -21,6 +21,8 @@ The legacy packages maptools, rgdal, and rgeos, underpinning the sp package,
 which was just loaded, will retire in October 2023.
 Please refer to R-spatial evolution reports for details, especially
 https://r-spatial.org/r/2023/05/15/evolution4.html.
+It may be desirable to make the sf package available;
+package maintainers should consider adding sf to Suggests:.
 The sp package is now running under evolution status 2
      (status 2 uses the sf package in place of rgdal)
 > xy = expand.grid(x = 1:4, y = 1:4)
@@ -52,4 +54,4 @@ Coordinate Reference System (CRS) arguments: NA
 > 
 > proc.time()
    user  system elapsed 
-  0.388   0.047   0.426 
+  0.456   0.045   0.495 

--- a/tests/spplot.Rout.save
+++ b/tests/spplot.Rout.save
@@ -17,10 +17,12 @@ Type 'q()' to quit R.
 
 > options("rgdal_show_exportToProj4_warnings"="none")
 > library(sp)
-The legacy packages maptools, rgdal, and rgeos, underpinning this package
-will retire shortly. Please refer to R-spatial evolution reports on
-https://r-spatial.org/r/2023/05/15/evolution4.html for details.
-This package is now running under evolution status 2 
+The legacy packages maptools, rgdal, and rgeos, underpinning the sp package,
+which was just loaded, will retire in October 2023.
+Please refer to R-spatial evolution reports for details, especially
+https://r-spatial.org/r/2023/05/15/evolution4.html.
+The sp package is now running under evolution status 2
+     (status 2 uses the sf package in place of rgdal)
 > xy = expand.grid(x = 1:4, y = 1:4)
 > xy.sp = SpatialPoints(xy)
 > gridded(xy.sp) = T
@@ -50,4 +52,4 @@ Coordinate Reference System (CRS) arguments: NA
 > 
 > proc.time()
    user  system elapsed 
-  0.376   0.059   0.425 
+  0.388   0.047   0.426 

--- a/tests/zerodist.Rout.save
+++ b/tests/zerodist.Rout.save
@@ -20,7 +20,7 @@ Type 'q()' to quit R.
 The legacy packages maptools, rgdal, and rgeos, underpinning this package
 will retire shortly. Please refer to R-spatial evolution reports on
 https://r-spatial.org/r/2023/05/15/evolution4.html for details.
-This package is now running under evolution status 0 
+This package is now running under evolution status 2 
 > data(meuse)
 > # pick 10 rows
 > n = 10
@@ -124,4 +124,4 @@ Data attributes:
 > 
 > proc.time()
    user  system elapsed 
-  0.220   0.044   0.254 
+  0.224   0.040   0.254 

--- a/tests/zerodist.Rout.save
+++ b/tests/zerodist.Rout.save
@@ -21,6 +21,8 @@ The legacy packages maptools, rgdal, and rgeos, underpinning the sp package,
 which was just loaded, will retire in October 2023.
 Please refer to R-spatial evolution reports for details, especially
 https://r-spatial.org/r/2023/05/15/evolution4.html.
+It may be desirable to make the sf package available;
+package maintainers should consider adding sf to Suggests:.
 The sp package is now running under evolution status 2
      (status 2 uses the sf package in place of rgdal)
 > data(meuse)
@@ -126,4 +128,4 @@ Data attributes:
 > 
 > proc.time()
    user  system elapsed 
-  0.215   0.051   0.256 
+  0.251   0.031   0.274 

--- a/tests/zerodist.Rout.save
+++ b/tests/zerodist.Rout.save
@@ -17,10 +17,12 @@ Type 'q()' to quit R.
 
 > options("rgdal_show_exportToProj4_warnings"="none")
 > library(sp)
-The legacy packages maptools, rgdal, and rgeos, underpinning this package
-will retire shortly. Please refer to R-spatial evolution reports on
-https://r-spatial.org/r/2023/05/15/evolution4.html for details.
-This package is now running under evolution status 2 
+The legacy packages maptools, rgdal, and rgeos, underpinning the sp package,
+which was just loaded, will retire in October 2023.
+Please refer to R-spatial evolution reports for details, especially
+https://r-spatial.org/r/2023/05/15/evolution4.html.
+The sp package is now running under evolution status 2
+     (status 2 uses the sf package in place of rgdal)
 > data(meuse)
 > # pick 10 rows
 > n = 10
@@ -124,4 +126,4 @@ Data attributes:
 > 
 > proc.time()
    user  system elapsed 
-  0.224   0.040   0.254 
+  0.215   0.051   0.256 

--- a/vignettes/retiring_rgdal_geos_1.Rmd
+++ b/vignettes/retiring_rgdal_geos_1.Rmd
@@ -194,13 +194,18 @@ colnames(slot(meuse, "coords"))
 ```{r}
 str(meuse$x)
 ```
-So far so good, but round-tripping changes the column names of the matrix of points:
+So far so good, but round-tripping if `sf` is available changes the column names of the matrix of points:
 
 ```{r}
+run <- requireNamespace("sf", quietly = TRUE)
+```
+
+
+```{r, eval=run}
 meuse_rt <- as(sf::st_as_sf(meuse), "Spatial")
 names(meuse_rt)
 ```
-```{r}
+```{r, eval=run}
 colnames(slot(meuse_rt, "coords"))
 ```
 


### PR DESCRIPTION
This flips default status from `0L` to `2L`, and adds extra messages for places where code may touch `rgeos`.

If possible, release after local checks. Rev-dep failures:

"dartR"     https://github.com/green-striped-gecko/dartR/issues/604

"dispeRse"  https://github.com/jgregoriods/dispeRse/issues/1

"ecospat"   https://github.com/ecospat/ecospat/issues/41

"geoviz"    https://github.com/neilcharles/geoviz/issues/42

"track2KBA" https://github.com/BirdLifeInternational/track2kba/issues/43

"usmap"    https://github.com/pdil/usmap/issues/70


Because of the way it was set up, I can't raise an issue in https://github.com/r-spatial/asdar-book.org to remind us that https://github.com/rsbivand/sf_asdar2ed should be folded into the legacy site between now and October. When we archive the three packages, the active code should be that for `sf` (with `terra` tracks for the three chapters in addition).