### PR TITLE
update minimum R version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Authors@R: c(person("Edzer", "Pebesma", role = c("aut", "cre"),
                         person("Finn", "Lindgren", role = "ctb"),
 			person("Josh", "O'Brien", role = "ctb"),
 			person("Joseph", "O'Rourke", role = "ctb"))
-Depends: R (>= 3.0.0), methods
+Depends: R (>= 3.2.0), methods
 Imports: utils, stats, graphics, grDevices, lattice, grid
 Suggests: RColorBrewer, rgdal (>= 1.2-3), rgeos (>= 0.3-13), gstat, maptools, deldir, knitr, rmarkdown, sf, terra, raster
 Description: Classes and methods for spatial


### PR DESCRIPTION
Current sp cannot be installed in R <= 3.0.2 because the `MAYBE_REFERENCED` macro was unavailable.
NEWS.Rd uses the `\CRANpkg` Rd macro which only exists in R >= 3.2.0.