### PR TITLE
accommodate "NAs" spelling from R-devel

### DIFF
--- a/tests/base.R
+++ b/tests/base.R
@@ -1,4 +1,6 @@
 options("rgdal_show_exportToProj4_warnings"="none")
+source("utils/print.R")
+
 library(sp)
 data(meuse)
 x = meuse[1:10, ] # limit the output

--- a/tests/base.Rout.save
+++ b/tests/base.Rout.save
@@ -1,7 +1,7 @@
 
-R version 4.3.1 (2023-06-16) -- "Beagle Scouts"
-Copyright (C) 2023 The R Foundation for Statistical Computing
-Platform: x86_64-pc-linux-gnu (64-bit)
+R version 4.5.2 (2025-10-31) -- "[Not] Part in a Rumble"
+Copyright (C) 2025 The R Foundation for Statistical Computing
+Platform: x86_64-pc-linux-gnu
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
 You are welcome to redistribute it under certain conditions.
@@ -16,6 +16,8 @@ Type 'demo()' for some demos, 'help()' for on-line help, or
 Type 'q()' to quit R.
 
 > options("rgdal_show_exportToProj4_warnings"="none")
+> source("utils/print.R")
+> 
 > library(sp)
 > data(meuse)
 > x = meuse[1:10, ] # limit the output
@@ -191,7 +193,7 @@ Data attributes:
  Ga     :2   Mean   :174.5  
  Ag     :1   3rd Qu.:277.5  
  (Other):1   Max.   :470.0  
- NA's   :1                  
+ NAs    :1                  
 > 
 > x[1:10] # first 10 columns
         coordinates cadmium copper lead zinc  elev       dist   om ffreq soil
@@ -460,4 +462,4 @@ Data attributes:
 > 
 > proc.time()
    user  system elapsed 
-  0.691   0.045   0.730 
+  0.322   0.052   0.365 

--- a/tests/pass1.R
+++ b/tests/pass1.R
@@ -1,4 +1,6 @@
 options("rgdal_show_exportToProj4_warnings"="none")
+source("utils/print.R")
+
 library(sp)
 data(meuse)
 x = meuse
@@ -61,9 +63,9 @@ SlDf = SpatialLinesDataFrame(Sl, data.frame(xx = c("foo", "bar")), match.ID = FA
 summary(as(SlDf, "SpatialPointsDataFrame"))
 
 meuse[["xxx"]] = log(meuse$zinc)
-summary(meuse)
+print(summary(meuse))
 meuse$xxy = log(meuse[["zinc"]])
-summary(meuse)
+print(summary(meuse))
 
 # test behaviour on zero-length objects:
 demo(meuse, ask = FALSE, echo = FALSE)
@@ -81,11 +83,11 @@ dim(subset(meuse, F, 0))
 dim(meuse.grid[0,])
 fullgrid(meuse.grid) = TRUE
 dim(meuse.grid[0,])
-summary(meuse.grid[0,])
+print(summary(meuse.grid[0,]))
 dim(meuse.grid[,0])
-summary(meuse.grid[,0])
+print(summary(meuse.grid[,0]))
 dim(meuse.grid[0,,0])
-summary(meuse.grid[0,,0])
+print(summary(meuse.grid[0,,0]))
 
 # SpatialPolygons:
 L = as(meuse.riv, "SpatialPolygons")

--- a/tests/pass1.Rout.save
+++ b/tests/pass1.Rout.save
@@ -1,7 +1,7 @@
 
-R version 4.3.2 (2023-10-31) -- "Eye Holes"
-Copyright (C) 2023 The R Foundation for Statistical Computing
-Platform: x86_64-pc-linux-gnu (64-bit)
+R version 4.5.2 (2025-10-31) -- "[Not] Part in a Rumble"
+Copyright (C) 2025 The R Foundation for Statistical Computing
+Platform: x86_64-pc-linux-gnu
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
 You are welcome to redistribute it under certain conditions.
@@ -16,6 +16,8 @@ Type 'demo()' for some demos, 'help()' for on-line help, or
 Type 'q()' to quit R.
 
 > options("rgdal_show_exportToProj4_warnings"="none")
+> source("utils/print.R")
+> 
 > library(sp)
 > data(meuse)
 > x = meuse
@@ -70,7 +72,7 @@ Data attributes:
          Mean   : 7.478   Fw     :10          Mean   : 469.7  
          3rd Qu.: 9.000   Ab     : 8          3rd Qu.: 674.5  
          Max.   :17.000   (Other):25          Max.   :1839.0  
-         NA's   :2        NA's   : 1                          
+         NAs    :2        NAs    : 1                          
       dist             copper          cadmium       soil       dist.m      
  Min.   :0.00000   Min.   : 14.00   Min.   : 0.200   1:97   Min.   :  10.0  
  1st Qu.:0.07569   1st Qu.: 23.00   1st Qu.: 0.800   2:46   1st Qu.:  80.0  
@@ -215,7 +217,7 @@ Data attributes:
                     Max.   :2.000                      Max.   :2.000  
 > 
 > meuse[["xxx"]] = log(meuse$zinc)
-> summary(meuse)
+> print(summary(meuse))
        x                y             cadmium           copper      
  Min.   :178605   Min.   :329714   Min.   : 0.200   Min.   : 14.00  
  1st Qu.:179371   1st Qu.:330762   1st Qu.: 0.800   1st Qu.: 23.00  
@@ -239,7 +241,7 @@ Data attributes:
  Mean   : 7.478                         Fw     :10   Mean   : 290.3  
  3rd Qu.: 9.000                         Ab     : 8   3rd Qu.: 450.0  
  Max.   :17.000                         (Other):25   Max.   :1000.0  
- NA's   :2                              NA's   : 1                   
+ NAs    :2                              NAs    : 1                   
       xxx       
  Min.   :4.727  
  1st Qu.:5.288  
@@ -249,7 +251,7 @@ Data attributes:
  Max.   :7.517  
                 
 > meuse$xxy = log(meuse[["zinc"]])
-> summary(meuse)
+> print(summary(meuse))
        x                y             cadmium           copper      
  Min.   :178605   Min.   :329714   Min.   : 0.200   Min.   : 14.00  
  1st Qu.:179371   1st Qu.:330762   1st Qu.: 0.800   1st Qu.: 23.00  
@@ -273,7 +275,7 @@ Data attributes:
  Mean   : 7.478                         Fw     :10   Mean   : 290.3  
  3rd Qu.: 9.000                         Ab     : 8   3rd Qu.: 450.0  
  Max.   :17.000                         (Other):25   Max.   :1000.0  
- NA's   :2                              NA's   : 1                   
+ NAs    :2                              NAs    : 1                   
       xxx             xxy       
  Min.   :4.727   Min.   :4.727  
  1st Qu.:5.288   1st Qu.:5.288  
@@ -315,7 +317,7 @@ NULL
 > fullgrid(meuse.grid) = TRUE
 > dim(meuse.grid[0,])
 [1] 8112    5
-> summary(meuse.grid[0,])
+> print(summary(meuse.grid[0,]))
 Object of class SpatialGridDataFrame
 Coordinates:
      min    max
@@ -332,10 +334,10 @@ y            329620       40       104
 Data attributes:
   part.a         part.b          dist           soil          ffreq        
  Mode:logical   Mode:logical   Mode:logical   Mode:logical   Mode:logical  
- NA's:8112      NA's:8112      NA's:8112      NA's:8112      NA's:8112     
+ NAs :8112      NAs :8112      NAs :8112      NAs :8112      NAs :8112     
 > dim(meuse.grid[,0])
 [1] 8112    5
-> summary(meuse.grid[,0])
+> print(summary(meuse.grid[,0]))
 Object of class SpatialGridDataFrame
 Coordinates:
      min    max
@@ -352,10 +354,10 @@ y            329620       40       104
 Data attributes:
   part.a         part.b          dist           soil          ffreq        
  Mode:logical   Mode:logical   Mode:logical   Mode:logical   Mode:logical  
- NA's:8112      NA's:8112      NA's:8112      NA's:8112      NA's:8112     
+ NAs :8112      NAs :8112      NAs :8112      NAs :8112      NAs :8112     
 > dim(meuse.grid[0,,0])
 [1] 8112    0
-> summary(meuse.grid[0,,0])
+> print(summary(meuse.grid[0,,0]))
 Object of class SpatialGridDataFrame
 Coordinates:
      min    max
@@ -369,6 +371,8 @@ Grid attributes:
   cellcentre.offset cellsize cells.dim
 x            178460       40        78
 y            329620       40       104
+Data attributes:
+character(0)
 > 
 > # SpatialPolygons:
 > L = as(meuse.riv, "SpatialPolygons")
@@ -598,4 +602,4 @@ Error in SpatialPointsDataFrame(pts, df, match.ID = TRUE) :
 > 
 > proc.time()
    user  system elapsed 
-  1.033   1.316   0.843 
+  0.783   0.067   0.842 

--- a/tests/sp1.R
+++ b/tests/sp1.R
@@ -1,4 +1,6 @@
 options("rgdal_show_exportToProj4_warnings"="none")
+source("utils/print.R")
+
 library(sp)
 data(meuse)
 x = meuse

--- a/tests/sp1.Rout.save
+++ b/tests/sp1.Rout.save
@@ -1,7 +1,7 @@
 
-R version 4.3.1 (2023-06-16) -- "Beagle Scouts"
-Copyright (C) 2023 The R Foundation for Statistical Computing
-Platform: x86_64-pc-linux-gnu (64-bit)
+R version 4.5.2 (2025-10-31) -- "[Not] Part in a Rumble"
+Copyright (C) 2025 The R Foundation for Statistical Computing
+Platform: x86_64-pc-linux-gnu
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
 You are welcome to redistribute it under certain conditions.
@@ -16,6 +16,8 @@ Type 'demo()' for some demos, 'help()' for on-line help, or
 Type 'q()' to quit R.
 
 > options("rgdal_show_exportToProj4_warnings"="none")
+> source("utils/print.R")
+> 
 > library(sp)
 > data(meuse)
 > x = meuse
@@ -92,7 +94,7 @@ Data attributes:
  Mean   : 8.165   Mean   :0.24002   Mean   : 7.478                        
  3rd Qu.: 8.955   3rd Qu.:0.36407   3rd Qu.: 9.000                        
  Max.   :10.520   Max.   :0.88039   Max.   :17.000                        
-                                    NA's   :2                             
+                                    NAs    :2                             
     landuse       dist.m      
  W      :50   Min.   :  10.0  
  Ah     :39   1st Qu.:  80.0  
@@ -100,7 +102,7 @@ Data attributes:
  Fw     :10   Mean   : 290.3  
  Ab     : 8   3rd Qu.: 450.0  
  (Other):25   Max.   :1000.0  
- NA's   : 1                   
+ NAs    : 1                   
 > coordinates(x)
     xcoord ycoord
 1   181072 333611
@@ -331,4 +333,4 @@ Data attributes:
 > 
 > proc.time()
    user  system elapsed 
-  0.577   0.051   0.622 
+  0.263   0.037   0.291 

--- a/tests/utils/print.R
+++ b/tests/utils/print.R
@@ -1,0 +1,10 @@
+## print "NAs" as in R >= 4.6.0 to match reference output
+if (getRversion() < "4.6.0") {
+    print <- function (x) {
+        if (inherits(x, "summary.Spatial"))
+            x$data <- sub("NA's", "NAs ", x$data, fixed = TRUE)
+        else if (is.table(x) && is.character(x))
+            x <- sub("NA's", "NAs ", x, fixed = TRUE)
+        base::print(x)
+    }
+}

--- a/tests/zerodist.R
+++ b/tests/zerodist.R
@@ -1,4 +1,6 @@
 options("rgdal_show_exportToProj4_warnings"="none")
+source("utils/print.R")
+
 library(sp)
 data(meuse)
 # pick 10 rows

--- a/tests/zerodist.Rout.save
+++ b/tests/zerodist.Rout.save
@@ -1,7 +1,7 @@
 
-R version 4.3.1 (2023-06-16) -- "Beagle Scouts"
-Copyright (C) 2023 The R Foundation for Statistical Computing
-Platform: x86_64-pc-linux-gnu (64-bit)
+R version 4.5.2 (2025-10-31) -- "[Not] Part in a Rumble"
+Copyright (C) 2025 The R Foundation for Statistical Computing
+Platform: x86_64-pc-linux-gnu
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
 You are welcome to redistribute it under certain conditions.
@@ -16,6 +16,8 @@ Type 'demo()' for some demos, 'help()' for on-line help, or
 Type 'q()' to quit R.
 
 > options("rgdal_show_exportToProj4_warnings"="none")
+> source("utils/print.R")
+> 
 > library(sp)
 > data(meuse)
 > # pick 10 rows
@@ -65,7 +67,7 @@ Data attributes:
  Mean   : 8.165   Mean   :0.24002   Mean   : 7.478                        
  3rd Qu.: 8.955   3rd Qu.:0.36407   3rd Qu.: 9.000                        
  Max.   :10.520   Max.   :0.88039   Max.   :17.000                        
-                                    NA's   :2                             
+                                    NAs    :2                             
     landuse       dist.m      
  W      :50   Min.   :  10.0  
  Ah     :39   1st Qu.:  80.0  
@@ -73,7 +75,7 @@ Data attributes:
  Fw     :10   Mean   : 290.3  
  Ab     : 8   3rd Qu.: 450.0  
  (Other):25   Max.   :1000.0  
- NA's   : 1                   
+ NAs    : 1                   
 > meusedup3 <- subset(meusedup, !(1:nrow(meusedup) %in% zd[,2]))
 > print(summary(meusedup3))
 Object of class SpatialPointsDataFrame
@@ -100,7 +102,7 @@ Data attributes:
  Mean   : 8.165   Mean   :0.24002   Mean   : 7.478                        
  3rd Qu.: 8.955   3rd Qu.:0.36407   3rd Qu.: 9.000                        
  Max.   :10.520   Max.   :0.88039   Max.   :17.000                        
-                                    NA's   :2                             
+                                    NAs    :2                             
     landuse       dist.m      
  W      :50   Min.   :  10.0  
  Ah     :39   1st Qu.:  80.0  
@@ -108,7 +110,7 @@ Data attributes:
  Fw     :10   Mean   : 290.3  
  Ab     : 8   3rd Qu.: 450.0  
  (Other):25   Max.   :1000.0  
- NA's   : 1                   
+ NAs    : 1                   
 > dim(meuse)
 [1] 155  14
 > dim(meusedup2)
@@ -120,4 +122,4 @@ Data attributes:
 > 
 > proc.time()
    user  system elapsed 
-  0.544   0.048   0.586 
+  0.257   0.044   0.291 


### PR DESCRIPTION
This is a minimal patch to resolve differences from reference output in tests due to the recent "NA's" -> "NAs" fix in R-devel's `summary` methods (cf. [PR#18948](https://bugs.r-project.org/show_bug.cgi?id=18948)).

Next step after this is merged should be to also take care of output differences due to the new default summary for character vectors (cf. [PR#16750](https://bugs.r-project.org/show_bug.cgi?id=16750)) that affects `tests/pass1.Rout.save`. I'd argue that this reveals a regression in sp for R >= 4.0.0: `SpatialLines2SpatialPointsDataFrame` should really consistently produce `Lines.ID` as a factor. I could prepare a PR for that as well.