### PR TITLE
use factor variables consistently as in R < 4

### DIFF
--- a/R/SpatialLines-methods.R
+++ b/R/SpatialLines-methods.R
@@ -266,7 +266,7 @@ SpatialLines2SpatialPointsDataFrame = function(from) {
 	L2 = rep(IDs, times = sapply(L, length))
 	L3 = rep(1:length(from@lines), times = sapply(L, length))
 	L = unlist(L)
-	SpatialPointsDataFrame(spp, data.frame(Lines.NR = L3, Lines.ID=L2, 
+	SpatialPointsDataFrame(spp, data.frame(Lines.NR = L3, Lines.ID = factor(L2),
 		Line.NR=L))
 }
 setAs("SpatialLines", "SpatialPointsDataFrame", function(from)

--- a/tests/pass1.R
+++ b/tests/pass1.R
@@ -59,7 +59,7 @@ Sl = SpatialLines(list(S1,S2))
 summary(as(polys, "SpatialLines"))
 summary(as(Sl, "SpatialPoints"))
 summary(as(Sl, "SpatialPointsDataFrame"))
-SlDf = SpatialLinesDataFrame(Sl, data.frame(xx = c("foo", "bar")), match.ID = FALSE)
+SlDf = SpatialLinesDataFrame(Sl, data.frame(xx = factor(c("foo", "bar"))), match.ID = FALSE)
 summary(as(SlDf, "SpatialPointsDataFrame"))
 
 meuse[["xxx"]] = log(meuse$zinc)
@@ -96,7 +96,7 @@ length(L[0])
 summary(L[0])
 
 # SpatialPolygonsDataFrame:
-L$something = "bla"
+L$something = factor("bla")
 class(L)
 length(L[1])
 summary(L[1])
@@ -110,7 +110,7 @@ length(L[0])
 summary(L[0])
 
 # SpatialLinesDataFrame
-L$something = "bla"
+L$something = factor("bla")
 class(L)
 length(L[1])
 summary(L[1])

--- a/tests/pass1.Rout.save
+++ b/tests/pass1.Rout.save
@@ -190,14 +190,14 @@ Is projected: NA
 proj4string : [NA]
 Number of points: 9
 Data attributes:
-    Lines.NR       Lines.ID            Line.NR     
- Min.   :1.000   Length:9           Min.   :1.000  
- 1st Qu.:1.000   Class :character   1st Qu.:1.000  
- Median :1.000   Mode  :character   Median :1.000  
- Mean   :1.333                      Mean   :1.333  
- 3rd Qu.:2.000                      3rd Qu.:2.000  
- Max.   :2.000                      Max.   :2.000  
-> SlDf = SpatialLinesDataFrame(Sl, data.frame(xx = c("foo", "bar")), match.ID = FALSE)
+    Lines.NR     Lines.ID    Line.NR     
+ Min.   :1.000   a:6      Min.   :1.000  
+ 1st Qu.:1.000   b:3      1st Qu.:1.000  
+ Median :1.000            Median :1.000  
+ Mean   :1.333            Mean   :1.333  
+ 3rd Qu.:2.000            3rd Qu.:2.000  
+ Max.   :2.000            Max.   :2.000  
+> SlDf = SpatialLinesDataFrame(Sl, data.frame(xx = factor(c("foo", "bar"))), match.ID = FALSE)
 > summary(as(SlDf, "SpatialPointsDataFrame"))
 Object of class SpatialPointsDataFrame
 Coordinates:
@@ -208,13 +208,13 @@ Is projected: NA
 proj4string : [NA]
 Number of points: 9
 Data attributes:
-      xx               Lines.NR       Lines.ID            Line.NR     
- Length:9           Min.   :1.000   Length:9           Min.   :1.000  
- Class :character   1st Qu.:1.000   Class :character   1st Qu.:1.000  
- Mode  :character   Median :1.000   Mode  :character   Median :1.000  
-                    Mean   :1.333                      Mean   :1.333  
-                    3rd Qu.:2.000                      3rd Qu.:2.000  
-                    Max.   :2.000                      Max.   :2.000  
+   xx       Lines.NR     Lines.ID    Line.NR     
+ bar:3   Min.   :1.000   a:6      Min.   :1.000  
+ foo:6   1st Qu.:1.000   b:3      1st Qu.:1.000  
+         Median :1.000            Median :1.000  
+         Mean   :1.333            Mean   :1.333  
+         3rd Qu.:2.000            3rd Qu.:2.000  
+         Max.   :2.000            Max.   :2.000  
 > 
 > meuse[["xxx"]] = log(meuse$zinc)
 > print(summary(meuse))
@@ -371,8 +371,6 @@ Grid attributes:
   cellcentre.offset cellsize cells.dim
 x            178460       40        78
 y            329620       40       104
-Data attributes:
-character(0)
 > 
 > # SpatialPolygons:
 > L = as(meuse.riv, "SpatialPolygons")
@@ -392,7 +390,7 @@ proj4string :
 +k=0.9999079 +x_0=155000 +y_0=463000 +ellps=bessel +units=m +no_defs]
 > 
 > # SpatialPolygonsDataFrame:
-> L$something = "bla"
+> L$something = factor("bla")
 > class(L)
 [1] "SpatialPolygonsDataFrame"
 attr(,"package")
@@ -410,10 +408,8 @@ proj4string :
 [+proj=sterea +lat_0=52.1561605555556 +lon_0=5.38763888888889
 +k=0.9999079 +x_0=155000 +y_0=463000 +ellps=bessel +units=m +no_defs]
 Data attributes:
-  something        
- Length:1          
- Class :character  
- Mode  :character  
+ something
+ bla:1    
 > length(L[0])
 [1] 1
 > summary(L[0])
@@ -445,7 +441,7 @@ proj4string :
 +k=0.9999079 +x_0=155000 +y_0=463000 +ellps=bessel +units=m +no_defs]
 > 
 > # SpatialLinesDataFrame
-> L$something = "bla"
+> L$something = factor("bla")
 > class(L)
 [1] "SpatialLinesDataFrame"
 attr(,"package")
@@ -463,10 +459,8 @@ proj4string :
 [+proj=sterea +lat_0=52.1561605555556 +lon_0=5.38763888888889
 +k=0.9999079 +x_0=155000 +y_0=463000 +ellps=bessel +units=m +no_defs]
 Data attributes:
-  something        
- Length:1          
- Class :character  
- Mode  :character  
+ something
+ bla:1    
 > length(L[0])
 [1] 1
 > summary(L[0])

--- a/tests/utils/print.R
+++ b/tests/utils/print.R
@@ -1,7 +1,7 @@
 ## print "NAs" as in R >= 4.6.0 to match reference output
 if (getRversion() < "4.6.0") {
     print <- function (x) {
-        if (inherits(x, "summary.Spatial"))
+        if (inherits(x, "summary.Spatial") && !is.null(x$data))
             x$data <- sub("NA's", "NAs ", x$data, fixed = TRUE)
         else if (is.table(x) && is.character(x))
             x <- sub("NA's", "NAs ", x, fixed = TRUE)


### PR DESCRIPTION
Following up on #151, this avoids additional output differences with the new default `summary` for character vectors in R-devel (4.6.0).

`SpatialLines2SpatialPointsDataFrame()` should return the same `@data` structure regardless of using sp with R < or >= 4. (I couldn't find any uses of `Lines.ID` in CRAN packages so this fix only matters for sp's own tests.)