### PR TITLE
docs: remove stray \arguments, add links

### DIFF
--- a/man/Line-class.Rd
+++ b/man/Line-class.Rd
@@ -1,13 +1,12 @@
 \name{Line-class}
 \docType{class}
 \alias{Line-class}
-% \alias{coordinates,Line-method}
+% \alias{coordinates,Line-method} % -> in methods?coordinates
 
-\title{Class "Line" }
+\title{Class \code{"Line"}}
 \description{ class for line objects }
 \section{Objects from the Class}{
-Objects can be created by calls of the form \code{new("Line", ...)},
-or (preferred) by calls to the function \link{Line}
+Objects can be created by calls to the function \code{\link{Line}}.
 }
 \section{Slots}{
   \describe{
@@ -16,15 +15,18 @@ or (preferred) by calls to the function \link{Line}
   }
 }
 \section{Methods}{
-  \describe{
-    \item{coordinates}{\code{signature(obj = "Line")}: retrieve coordinates
-	from line }
-    \item{lines}{\code{signature(x = "Line")}: add lines to a plot }
-  }
+  There are methods for
+  \code{\link[=bbox-methods]{bbox}},
+  \code{\link[=coordinates-methods]{coordinates}},
+  \code{\link[=coordnames-methods]{coordnames}}, and
+  \code{\link[=spsample-methods]{spsample}}.
+
+  There is also a \code{\link{lines}} method to add lines to a plot.
 }
 \author{ Roger Bivand, Edzer Pebesma }
 
 \seealso{
-  \link{Lines-class}, \link{SpatialLines-class}
+  The generator function \code{\link{Line}}, and the related classes
+  \code{"\linkS4class{Lines}"} and \code{"\linkS4class{SpatialLines}"}.
 }
 \keyword{classes}

--- a/man/Lines-class.Rd
+++ b/man/Lines-class.Rd
@@ -1,34 +1,33 @@
 \name{Lines-class}
 \docType{class}
 \alias{Lines-class}
-% \alias{coordinates,Lines-method}
+% \alias{coordinates,Lines-method} % -> in methods?coordinates
 
-\title{Class "Lines" }
+\title{Class \code{"Lines"}}
 \description{ class for sets of line objects }
 \section{Objects from the Class}{
-Objects can be created by calls to the function \link{Line}
+Objects can be created by calls to the function \code{\link{Lines}}.
 }
 \section{Slots}{
   \describe{
     \item{\code{Lines}:}{Object of class \code{"list"}, containing elements
-	of class \link{Line-class}}
+	of class \code{"\linkS4class{Line}"}}
     \item{\code{ID}:}{\code{"character"} vector of length one, with unique identifier string}
   }
 }
 \section{Methods}{
-  \describe{
-    \item{coordinates}{\code{signature(obj = "Line")}: retrieve coordinates
-	from lines; returns list with matrices }
-    \item{lines}{\code{signature(x = "Line")}: add lines to a plot}
-  }
-}
-\arguments{
-\item{SL, Lines}{an Lines object}
-}
+  There are methods for
+  \code{\link[=bbox-methods]{bbox}},
+  \code{\link[=coordinates-methods]{coordinates}},
+  \code{\link[=coordnames-methods]{coordnames}}, and
+  \code{\link[=spsample-methods]{spsample}}.
 
+  There is also a \code{\link{lines}} method to add lines to a plot.
+}
 \author{ Roger Bivand, Edzer Pebesma }
 
 \seealso{
-  \link{Lines-class}, \link{SpatialLines-class}
+  The generator function \code{\link{Lines}}, and the related classes
+  \code{"\linkS4class{Line}"} and \code{"\linkS4class{SpatialLines}"}.
 }
 \keyword{classes}

--- a/man/bbox.Rd
+++ b/man/bbox.Rd
@@ -1,5 +1,6 @@
 \name{bbox-methods}
 \docType{methods}
+\alias{bbox-methods}
 \alias{bbox,Spatial-method}
 \alias{bbox,ANY-method}
 \alias{bbox,Line-method}


### PR DESCRIPTION
While experimenting with new QC checks, I noticed a stray `\arguments` section in `class?sp::Lines`. This patch removes it and tweaks some other parts of the help page (syncing also with that for the `Line`-class).